### PR TITLE
Adding LangStream

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,6 +266,7 @@ List of non-official ports of LangChain to other languages.
 - [Rivet](https://github.com/Ironclad/rivet): An IDE for creating complex AI agents and prompt chaining, and embedding it in your application. ![GitHub Repo stars](https://img.shields.io/github/stars/Ironclad/rivet?style=social)
 - [Promptfoo](https://github.com/promptfoo/promptfoo): Test your prompts. Evaluate and compare LLM outputs, catch regressions, and improve prompt quality. ![GitHub Repo stars](https://img.shields.io/github/stars/promptfoo/promptfoo?style=social)
 - [RestGPT](https://github.com/Yifan-Song793/RestGPT): An LLM-based autonomous agent controlling real-world applications via RESTful APIs ![GitHub Repo stars](https://img.shields.io/github/stars/Yifan-Song793/RestGPT?style=social)
+- [LangStream](https://github.com/LangStream/langstream): Framework for building and running event-driven LLM applications using no-code and Python (including LangChain-based) agents.  ![GitHub Repo stars](https://img.shields.io/github/stars/LangStream/langstream?style=social)
 
 ## Complement to this list
 


### PR DESCRIPTION
Hi @MCKevmeister. Nice work on curating this list of LangChain-related projects. We recently created a new open-source project called LangStream that enables event-driven LLM-based applications. It supports Python agents and comes pre-installed with LangChain, LlamaIndex, etc. 

I hope you will consider adding it to the list. Thanks!