### PR TITLE
add Pluto

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ List of non-official ports of LangChain to other languages.
 - [Llama2 Embedding Server](https://github.com/Dicklesworthstone/llama_embeddings_fastapi_service): Llama2 Embeddings FastAPI Service using LangChain ![GitHub Repo stars](https://img.shields.io/github/stars/Dicklesworthstone/llama_embeddings_fastapi_service?style=social)
 - [ChatAbstractions](https://github.com/andrewnguonly/ChatAbstractions): LangChain chat model abstractions for dynamic failover, load balancing, chaos engineering, and more! ![GitHub Repo stars](https://img.shields.io/github/stars/andrewnguonly/ChatAbstractions?style=social)
 - [MindSQL](https://github.com/Mindinventory/MindSQL) - A python package for Txt-to-SQL with self hosting functionalities and RESTful APIs compatible with proprietary as well as open source LLM.![GitHub Repo stars](https://img.shields.io/github/stars/mindinventory/mindsql?style=social)
+- [Pluto](https://github.com/pluto-lang/pluto): Simplify deploying LangChain applications on AWS by allowing you to define and utilize necessary cloud resources directly in your application code, automatically creating the required infrastructure. ![GitHub Repo stars](https://img.shields.io/github/stars/pluto-lang/pluto?style=social)
 
 ### Agents
 


### PR DESCRIPTION
Added Pluto to services.

[Pluto](https://github.com/pluto-lang/pluto) is a development tool that simplifies the process of deploying LangChain applications on AWS. With Pluto, you can directly define and utilize the necessary cloud resources within your application code, such as AWS SageMaker, DynamoDB, and more. Pluto automatically deduces the infrastructure resource needs of the app and proceeds to create these resources on the AWS. This simplifies the process of deploying your LangChain application, allowing you to focus on developing your application instead of worrying about setting up the required infrastructure.