### PR TITLE
Add Eino

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,6 +297,7 @@ List of non-official ports of LangChain to other languages.
 - [Claude Engineer](https://github.com/Doriandarko/claude-engineer): Claude Engineer is an interactive command-line interface (CLI) that leverages the power of Anthropic's Claude-3.5-Sonnet model to assist with software development tasks. ![GitHub Repo stars](https://img.shields.io/github/stars/Doriandarko/claude-engineer?style=social)
 - [AI Scientist](https://github.com/SakanaAI/AI-Scientist): The AI Scientist: Towards Fully Automated Open-Ended Scientific ![GitHub Repo stars](https://img.shields.io/github/stars/SakanaAI/AI-Scientist?style=social)
 - [DSPy](https://github.com/stanfordnlp/dspy): The framework for programming—not prompting—foundation models ![GitHub Repo stars](https://img.shields.io/github/stars/stanfordnlp/dspy?style=social)
+- [Eino](https://github.com/cloudwego/eino): Eino provides a Golang AI application development framework with various component integrations and the ability to orchestrate Chains and Graphs similar to LangChain and LangGraph. ![GitHub Repo stars](https://img.shields.io/github/stars/cloudwego/eino?style=social)
 
 ## Complement to this list
 


### PR DESCRIPTION
This PR adds [Eino](https://github.com/cloudwego/eino) to "Other LLM Frameworks". 

Eino is a Golang AI application development framework that is designed with references to LangChain, LangGraph, etc.  and provides APIs that align more with Golang programming conventions:
* It offers rich component integration and flexible extension methods based on Golang interfaces.
* It provides powerful component orchestration capabilities through Chain and Graph with strong typing.

Relevant links for more information: https://www.cloudwego.io/docs/eino