### PR TITLE
Add Agentic Radar to Services

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ List of non-official ports of LangChain to other languages.
 - [CopilotKit](https://github.com/CopilotKit/CopilotKit): A framework for building custom AI Copilots 🤖 in-app AI chatbots, in-app AI Agents, & AI-powered Textareas ![GitHub Repo stars](https://img.shields.io/github/stars/CopilotKit/CopilotKit?style=social)
 - [LangFair](https://github.com/cvs-health/langfair): LangFair is a Python library for conducting use-case-specific LLM bias and fairness assessments ![GitHub Repo stars](https://img.shields.io/github/stars/cvs-health/langfair?style=social)
 - [LangWatch](https://github.com/langwatch/langwatch): An Open Source tool for observing, evaluating and optimising your llm apps and prompts, which supports LangChain out of the box! ![GitHub Repo stars](https://img.shields.io/github/stars/langwatch/langwatch?style=social)
+- [Agentic Radar](https://github.com/splx-ai/agentic-radar) - Open-source CLI security scanner for agentic workflows. Scans your workflow’s source code, detects vulnerabilities, and generates an interactive visualization along with a detailed security report. ![GitHub Repo stars](https://img.shields.io/github/stars/splx-ai/agentic-radar?style=social)
 
 ### Agents
 


### PR DESCRIPTION
Hi,

I’d like to suggest adding [Agentic Radar](https://github.com/splx-ai/agentic-radar) — an open-source CLI tool for security analysis of agentic AI workflows. It supports frameworks like LangGraph, CrewAI, n8n, OpenAI Agents and others.

The tool can:
- Scan agentic workflow source code
- Detect vulnerabilities (CVE, OWASP)
- Generate interactive visualizations with remediation suggestions

I think you might find the tool to your liking because we currently support LangGraph and CrewAI - tools built on top of LangChain, and we're planning on adding support to other frameworks on your list like Dify, AutoGen, LlamaIndex, etc.

Also, if you'd be open to it, I'd love to suggest adding "Security" category, as more safety and security-focused tools are emerging.