### PR TITLE
docs: add AI Manifest + WellKnownAI as optional references (discoverability + snapshots)

### DIFF
--- a/README.md
+++ b/README.md
@@ -313,3 +313,9 @@ List of non-official ports of LangChain to other languages.
 - [Awesome LLM](https://github.com/Hannibal046/Awesome-LLM): Awesome-LLM: a curated list of Large Language Model resources. ![GitHub Repo stars](https://img.shields.io/github/stars/Hannibal046/Awesome-LLM?style=social)
 - [LLaMA Cult and More](https://github.com/shm007g/LLaMA-Cult-and-More): Keeping Track of Affordable LLMs, 🦙 Cult and More ![GitHub Repo stars](https://img.shields.io/github/stars/shm007g/LLaMA-Cult-and-More?style=social)
 - [Awesome Language Agents](https://github.com/ysymyth/awesome-language-agents): List of language agents based on paper "Cognitive Architectures for Language Agents" ![GitHub Repo stars](https://img.shields.io/github/stars/ysymyth/awesome-language-agents?style=social)
+
+
+
+
+- [AI Manifest](https://ai-manifest.org) - Optional reference for /.well-known/ai.json + OpenAPI/JSON Schema discovery (with MCP/agents.json mapping).
+- [WellKnownAI](https://wellknownai.org) - Registry/spec examples and public snapshots (no PII, mirroring allowed).


### PR DESCRIPTION
Adding two optional references for service/agent discovery and auditability:

- AI Manifest — optional reference for /.well-known/ai.json + OpenAPI/JSON Schema discovery (with MCP/agents.json mapping). https://ai-manifest.org
- WellKnownAI — registry/spec examples and public snapshots (no PII, mirroring allowed). https://wellknownai.org

Non-binding, community-driven; alphabetical order respected where applicable.