### PR TITLE
Add Neurolink to Other LLM Frameworks

### DIFF
--- a/README.md
+++ b/README.md
@@ -306,6 +306,7 @@ List of non-official ports of LangChain to other languages.
 - [Eino](https://github.com/cloudwego/eino): Eino provides a Golang AI application development framework with various component integrations and the ability to orchestrate Chains and Graphs similar to LangChain and LangGraph. ![GitHub Repo stars](https://img.shields.io/github/stars/cloudwego/eino?style=social)
 - [TensorZero](https://github.com/tensorzero/tensorzero): An open-source framework for building production-grade LLM applications. It unifies an LLM gateway, observability, optimization, evaluations, and experimentation. ![GitHub Repo stars](https://img.shields.io/github/stars/tensorzero/tensorzero?style=social)
 - [Bifrost](https://github.com/maximhq/bifrost): Bifrost is the fastest LLM gateway, with just 11μs overhead at 5,000 RPS, making it 50x faster than LiteLLM. ![GitHub Repo stars](https://img.shields.io/github/stars/maximhq/bifrost?style=social)
+- [Neurolink](https://github.com/juspay/neurolink): Multi-provider AI agent framework that unifies 12+ LLM providers (OpenAI, Google, Anthropic, AWS, Azure, Groq, etc.) with workflow orchestration capabilities. Production-grade framework with streaming, tool calling, caching, and enterprise features. Handles 15M+ requests/month at Juspay. ![GitHub Repo stars](https://img.shields.io/github/stars/juspay/neurolink?style=social)
 
 ## Complement to this list
 


### PR DESCRIPTION
Adding [Neurolink](https://github.com/juspay/neurolink), a multi-provider AI agent framework that unifies 12+ LLM providers with workflow orchestration capabilities.

**What is Neurolink:**
- Multi-provider AI agent framework
- Unifies 12+ LLM providers (OpenAI, Google, Anthropic, AWS, Azure, Groq, Together AI, Mistral, Cohere, Fireworks, Cloudflare, Ollama)
- Workflow orchestration for building complex AI applications
- Production-grade with streaming, tool calling, caching, and enterprise features
- Battle-tested at 15M+ requests/month at Juspay

**Why it belongs here:**
Neurolink is a framework alternative to LangChain that provides multi-provider abstraction and workflow orchestration capabilities, similar to other frameworks listed in this section (LlamaIndex, Haystack, Semantic Kernel, etc.).

**Open source:**
- License: Apache 2.0
- Repository: https://github.com/juspay/neurolink
- Active development and maintenance
- Production-ready and actively used

Following the contribution guidelines by adding the entry to the bottom of the "Other LLM Frameworks" section.