### PR TITLE
Add promptfoo to Services section

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ List of non-official ports of LangChain to other languages.
 - [LangWatch](https://github.com/langwatch/langwatch): An Open Source tool for observing, evaluating and optimising your llm apps and prompts, which supports LangChain out of the box! ![GitHub Repo stars](https://img.shields.io/github/stars/langwatch/langwatch?style=social)
 - [Agentic Radar](https://github.com/splx-ai/agentic-radar) - Open-source CLI security scanner for agentic workflows. Scans your workflow’s source code, detects vulnerabilities, and generates an interactive visualization along with a detailed security report. ![GitHub Repo stars](https://img.shields.io/github/stars/splx-ai/agentic-radar?style=social)
 - [UQLM](https://github.com/cvs-health/uqlm): UQLM: Uncertainty Quantification for Language Models, is a Python library for LLM hallucination detection using state-of-the-art uncertainty quantification techniques ![GitHub Repo stars](https://img.shields.io/github/stars/cvs-health/uqlm?style=social)
+- [promptfoo](https://github.com/promptfoo/promptfoo): Test and evaluate LLM applications built with LangChain. Compare prompts, models, and RAG pipelines. Red team with multi-turn attacks and catch security vulnerabilities in CI/CD. ![GitHub Repo stars](https://img.shields.io/github/stars/promptfoo/promptfoo?style=social)
 
 
 ### Agents


### PR DESCRIPTION
Hi! I'd like to add [promptfoo](https://github.com/promptfoo/promptfoo) to the Services section.

promptfoo is an open-source framework for testing and evaluating LLM applications. It works great with LangChain apps and helps developers:

- Compare prompts, models, and RAG pipelines
- Red team with multi-turn attack techniques (PAIR, tree-of-attacks, crescendo)
- Catch regressions and security vulnerabilities in CI/CD

It's used by over 250K developers and has been featured in OpenAI Build Hours and Anthropic's prompt evaluation courses.

Following the contribution guidelines, I've added it at the bottom of the Services list.

Thanks for maintaining this awesome list!