### PR TITLE
Add EntropyGuard to the tools list in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ List of non-official ports of LangChain to other languages.
 - [Agentic Radar](https://github.com/splx-ai/agentic-radar) - Open-source CLI security scanner for agentic workflows. Scans your workflow’s source code, detects vulnerabilities, and generates an interactive visualization along with a detailed security report. ![GitHub Repo stars](https://img.shields.io/github/stars/splx-ai/agentic-radar?style=social)
 - [UQLM](https://github.com/cvs-health/uqlm): UQLM: Uncertainty Quantification for Language Models, is a Python library for LLM hallucination detection using state-of-the-art uncertainty quantification techniques ![GitHub Repo stars](https://img.shields.io/github/stars/cvs-health/uqlm?style=social)
 - [promptfoo](https://github.com/promptfoo/promptfoo): Test and evaluate LLM applications built with LangChain. Compare prompts, models, and RAG pipelines. Red team with multi-turn attacks and catch security vulnerabilities in CI/CD. ![GitHub Repo stars](https://img.shields.io/github/stars/promptfoo/promptfoo?style=social)
-
+- [EntropyGuard](https://github.com/DamianSiuta/entropyguard) - CLI tool for semantic deduplication of RAG datasets locally on CPU (prevents context pollution).
 
 ### Agents
 


### PR DESCRIPTION
Why is this useful for LangChain users? Garbage in, Garbage out. Before loading documents into LangChain retrievers, developers often struggle with duplicate content bloating their Vector DBs and context windows.

EntropyGuard is a specialized, open-source CLI (MIT) to deduplicate these datasets locally using a hybrid (Hash + Semantic) approach. It ensures that the documents fed into LangChain are unique and high-quality.