### PR TITLE
Add PolicyLayer to Services section

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ List of non-official ports of LangChain to other languages.
 - [UQLM](https://github.com/cvs-health/uqlm): UQLM: Uncertainty Quantification for Language Models, is a Python library for LLM hallucination detection using state-of-the-art uncertainty quantification techniques ![GitHub Repo stars](https://img.shields.io/github/stars/cvs-health/uqlm?style=social)
 - [promptfoo](https://github.com/promptfoo/promptfoo): Test and evaluate LLM applications built with LangChain. Compare prompts, models, and RAG pipelines. Red team with multi-turn attacks and catch security vulnerabilities in CI/CD. ![GitHub Repo stars](https://img.shields.io/github/stars/promptfoo/promptfoo?style=social)
 - [Tenuo](https://github.com/tenuo-ai/tenuo): Capability-based authorization for AI agents. Task-scoped tokens with offline verification, proof-of-possession binding, and native LangChain/LangGraph integration. ![GitHub Repo stars](https://img.shields.io/github/stars/tenuo-ai/tenuo?style=social)
+- [PolicyLayer](https://policylayer.com): Non-custodial spending controls for AI agents with crypto wallets. Enforce daily limits, per-transaction caps, and recipient whitelists without holding private keys. [![npm](https://img.shields.io/npm/v/@policylayer/sdk)](https://www.npmjs.com/package/@policylayer/sdk)
 
 
 ### Agents


### PR DESCRIPTION
## Addition

Adding [PolicyLayer](https://policylayer.com) to the Services section.

**PolicyLayer** provides non-custodial spending controls for AI agents with crypto wallets. It enforces:
- Daily spending limits
- Per-transaction caps
- Recipient whitelists
- Two-gate cryptographic enforcement

All without holding private keys — the agent's keys stay on their infrastructure.

**Why it fits awesome-langchain:**
- Works with LangChain agents that need wallet access
- Similar to Tenuo (capability-based auth) but focused on spending limits
- Open source SDK on npm: `@policylayer/sdk`

**Links:**
- GitHub: https://github.com/PolicyLayer/PolicyLayer
- Docs: https://policylayer.com/docs
- npm: https://www.npmjs.com/package/@policylayer/sdk