### PR TITLE
Add PolicyLayer to Services section

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ List of non-official ports of LangChain to other languages.
 - [UQLM](https://github.com/cvs-health/uqlm): UQLM: Uncertainty Quantification for Language Models, is a Python library for LLM hallucination detection using state-of-the-art uncertainty quantification techniques ![GitHub Repo stars](https://img.shields.io/github/stars/cvs-health/uqlm?style=social)
 - [promptfoo](https://github.com/promptfoo/promptfoo): Test and evaluate LLM applications built with LangChain. Compare prompts, models, and RAG pipelines. Red team with multi-turn attacks and catch security vulnerabilities in CI/CD. ![GitHub Repo stars](https://img.shields.io/github/stars/promptfoo/promptfoo?style=social)
 - [Tenuo](https://github.com/tenuo-ai/tenuo): Capability-based authorization for AI agents. Task-scoped tokens with offline verification, proof-of-possession binding, and native LangChain/LangGraph integration. ![GitHub Repo stars](https://img.shields.io/github/stars/tenuo-ai/tenuo?style=social)
+- [PolicyLayer](https://github.com/PolicyLayer/PolicyLayer): Non-custodial spending controls for AI agents with crypto wallets. Enforces spending limits, recipient whitelists, and rate limiting without holding private keys. ![GitHub Repo stars](https://img.shields.io/github/stars/PolicyLayer/PolicyLayer?style=social)
 
 
 ### Agents


### PR DESCRIPTION
## Summary
Adds [PolicyLayer](https://github.com/PolicyLayer/PolicyLayer) to the Tools > Services section.

PolicyLayer provides non-custodial spending controls for AI agents with crypto wallets. It enforces spending limits, recipient whitelists, and rate limiting without holding private keys - complementing the security tools already listed in this section (Agentic Radar, promptfoo, Tenuo).

**Website:** https://policylayer.com
**npm:** https://www.npmjs.com/package/@policylayer/sdk