### PR TITLE
Add llm-chunker to the list of tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ List of non-official ports of LangChain to other languages.
 - [promptfoo](https://github.com/promptfoo/promptfoo): Test and evaluate LLM applications built with LangChain. Compare prompts, models, and RAG pipelines. Red team with multi-turn attacks and catch security vulnerabilities in CI/CD. ![GitHub Repo stars](https://img.shields.io/github/stars/promptfoo/promptfoo?style=social)
 - [far-search-tool](https://github.com/blueskylineassets/far-search-tool): LangChain tool for semantic search over Federal Acquisition Regulations (FAR). Enables AI agents to query U.S. government contracting rules and compliance requirements. ![GitHub Repo stars](https://img.shields.io/github/stars/blueskylineassets/far-search-tool?style=social)
 - [Tenuo](https://github.com/tenuo-ai/tenuo): Capability-based authorization for AI agents. Task-scoped tokens with offline verification, proof-of-possession binding, and native LangChain/LangGraph integration. ![GitHub Repo stars](https://img.shields.io/github/stars/tenuo-ai/tenuo?style=social)
+- [llm-chunker](https://github.com/Theeojeong/llm-chunker): LLM-powered semantic text splitter that chunks documents at meaningful boundaries (emotional shifts, topic changes, etc.) ![GitHub Repo stars](https://img.shields.io/github/stars/Theeojeong/llm-chunker?style=social)
 
 
 ### Agents


### PR DESCRIPTION
I've added llm-chunker to the Services section.

Description:
llm-chunker is an LLM-powered semantic text splitter that chunks documents at meaningful boundaries (emotional shifts, topic changes, legal sections, etc.) instead of fixed character counts. It helps improve RAG performance by keeping context intact.

Links:
- GitHub: https://github.com/Theeojeong/llm-chunker
- PyPI: https://pypi.org/project/llm-chunker/