### PR TITLE
Add langchain-registry-broker to Services section

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ List of non-official ports of LangChain to other languages.
 - [promptfoo](https://github.com/promptfoo/promptfoo): Test and evaluate LLM applications built with LangChain. Compare prompts, models, and RAG pipelines. Red team with multi-turn attacks and catch security vulnerabilities in CI/CD. ![GitHub Repo stars](https://img.shields.io/github/stars/promptfoo/promptfoo?style=social)
 - [far-search-tool](https://github.com/blueskylineassets/far-search-tool): LangChain tool for semantic search over Federal Acquisition Regulations (FAR). Enables AI agents to query U.S. government contracting rules and compliance requirements. ![GitHub Repo stars](https://img.shields.io/github/stars/blueskylineassets/far-search-tool?style=social)
 - [Tenuo](https://github.com/tenuo-ai/tenuo): Capability-based authorization for AI agents. Task-scoped tokens with offline verification, proof-of-possession binding, and native LangChain/LangGraph integration. ![GitHub Repo stars](https://img.shields.io/github/stars/tenuo-ai/tenuo?style=social)
+- [langchain-registry-broker](https://github.com/hashgraph-online/langchain-registry-broker): LangChain tools for discovering AI agents across 59,000+ agents in NANDA, MCP, A2A, Virtuals, and OpenRouter registries. ![GitHub Repo stars](https://img.shields.io/github/stars/hashgraph-online/langchain-registry-broker?style=social)
 
 
 ### Agents


### PR DESCRIPTION
## Summary

Adding [langchain-registry-broker](https://github.com/hashgraph-online/langchain-registry-broker) - a LangChain tools package for discovering AI agents.

**What it does:** Provides LangChain-native tools (`StructuredTool` subclasses) that let agents search and discover 59,000+ AI agents across multiple registries:
- NANDA (agentic protocol)
- MCP (Model Context Protocol)
- A2A (Agent-to-Agent)
- Virtuals
- OpenRouter

**Why it fits Services:** Like `far-search-tool` provides LangChain tools for FAR search, this provides LangChain tools for agent discovery. It's an npm package (`@hol-org/langchain-registry-broker`) that integrates directly with LangChain agents.

**Usage:**
```typescript
import { createRegistryBrokerTools } from '@hol-org/langchain-registry-broker';
import { AgentExecutor, createOpenAIFunctionsAgent } from 'langchain/agents';

const tools = createRegistryBrokerTools();
const agent = await createOpenAIFunctionsAgent({ llm, tools, prompt });
```

- **NPM:** https://www.npmjs.com/package/@hol-org/langchain-registry-broker
- **GitHub:** https://github.com/hashgraph-online/langchain-registry-broker
- **License:** Apache 2.0