### PR TITLE
Add Veritensor to the Services

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ List of non-official ports of LangChain to other languages.
 - [promptfoo](https://github.com/promptfoo/promptfoo): Test and evaluate LLM applications built with LangChain. Compare prompts, models, and RAG pipelines. Red team with multi-turn attacks and catch security vulnerabilities in CI/CD. ![GitHub Repo stars](https://img.shields.io/github/stars/promptfoo/promptfoo?style=social)
 - [far-search-tool](https://github.com/blueskylineassets/far-search-tool): LangChain tool for semantic search over Federal Acquisition Regulations (FAR). Enables AI agents to query U.S. government contracting rules and compliance requirements. ![GitHub Repo stars](https://img.shields.io/github/stars/blueskylineassets/far-search-tool?style=social)
 - [Tenuo](https://github.com/tenuo-ai/tenuo): Capability-based authorization for AI agents. Task-scoped tokens with offline verification, proof-of-possession binding, and native LangChain/LangGraph integration. ![GitHub Repo stars](https://img.shields.io/github/stars/tenuo-ai/tenuo?style=social)
+- [Veritensor](https://github.com/ArseniiBrazhnyk/Veritensor) - Security service for AI/ML artifacts in LangChain workflows. Provides static analysis, integrity verification, and license compliance checks before deployment. ![GitHub Repo stars](https://img.shields.io/github/stars/ArseniiBrazhnyk/Veritensor?style=social)
 
 
 ### Agents


### PR DESCRIPTION
Hi! I would like to add **Veritensor** to the Services section.

Veritensor is an open-source security service and CLI for securing AI/ML artifacts used in LangChain-based applications and workflows.

It performs static analysis of model files (e.g. Pickle, PyTorch) to detect malicious behavior, and verifies integrity and license compliance against upstream registries such as Hugging Face. This helps teams prevent unsafe or non-compliant models from being introduced into LangChain applications as part of CI/CD or pre-deployment checks.

**Key Differentiators:**
1.  **Identity Verification:** Unlike standard scanners, Veritensor queries the Hugging Face API to verify that the local model hash matches the official upstream source bit-for-bit (detects Man-in-the-Middle attacks and corruption).
2.  **Deep Static Analysis:** Emulates the Pickle VM stack to detect obfuscated RCE payloads in PyTorch/Pickle files without execution.
3.  **Supply Chain Trust:** Integrates with **Sigstore Cosign** to cryptographically sign artifacts that pass the scan.

*   **Repo:** https://github.com/ArseniiBrazhnyk/Veritensor
*   **License:** Apache 2.0
*   **Install:** `pip install veritensor`

Thanks!