### PR TITLE
Add AgentFund to Agents section

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ List of non-official ports of LangChain to other languages.
 
 ### Agents
 
+- [AgentFund](https://github.com/Riobot-Grind/agentfund-escrow): Crowdfunding platform for AI agents on Base chain. Milestone-based escrow contracts enabling agents to raise funds, deliver work, and get paid autonomously. ![GitHub Repo stars](https://img.shields.io/github/stars/Riobot-Grind/agentfund-escrow?style=social)
 - [Private GPT](https://github.com/imartinez/privateGPT): Interact privately with your documents using the power of GPT, 100% privately, no data leaks ![GitHub Repo stars](https://img.shields.io/github/stars/imartinez/privateGPT?style=social)
 - [CollosalAI Chat](https://github.com/hpcaitech/ColossalAI/tree/main/applications/Chat): implement LLM with RLHF, powered by the Colossal-AI project ![GitHub Repo stars](https://img.shields.io/github/stars/hpcaitech/ColossalAI?style=social)
 - [CrewAI](https://github.com/joaomdmoura/crewai): Cutting-edge framework for orchestrating role-playing, autonomous AI agents. ![GitHub Repo stars](https://img.shields.io/github/stars/joaomdmoura/crewai?style=social)


### PR DESCRIPTION
## AgentFund

Crowdfunding platform for AI agents on Base chain.

**Features:**
- Milestone-based escrow contracts for AI agent tasks
- Autonomous fund raising and payment processing
- Trustless delivery verification
- Built on Base L2

**Links:**
- GitHub: https://github.com/Riobot-Grind/agentfund-escrow
- Contract: `0x6a4420f696c9ba6997f41dddc15b938b54aa009a` (Base Mainnet)

Adding AgentFund to the Agents section as it enables LangChain agents (and other AI agents) to receive funding, complete milestone-based tasks, and get paid autonomously via smart contracts.