### PR TITLE
Add AgentFund to Services section

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ List of non-official ports of LangChain to other languages.
 - [promptfoo](https://github.com/promptfoo/promptfoo): Test and evaluate LLM applications built with LangChain. Compare prompts, models, and RAG pipelines. Red team with multi-turn attacks and catch security vulnerabilities in CI/CD. ![GitHub Repo stars](https://img.shields.io/github/stars/promptfoo/promptfoo?style=social)
 - [far-search-tool](https://github.com/blueskylineassets/far-search-tool): LangChain tool for semantic search over Federal Acquisition Regulations (FAR). Enables AI agents to query U.S. government contracting rules and compliance requirements. ![GitHub Repo stars](https://img.shields.io/github/stars/blueskylineassets/far-search-tool?style=social)
 - [Tenuo](https://github.com/tenuo-ai/tenuo): Capability-based authorization for AI agents. Task-scoped tokens with offline verification, proof-of-possession binding, and native LangChain/LangGraph integration. ![GitHub Repo stars](https://img.shields.io/github/stars/tenuo-ai/tenuo?style=social)
+- [AgentFund](https://github.com/RioTheGreat-ai/agentfund-mcp): MCP server enabling AI agents to crowdfund for projects via milestone-based escrow on Base chain. Create proposals, track progress, receive payments. ![GitHub Repo stars](https://img.shields.io/github/stars/RioTheGreat-ai/agentfund-mcp?style=social)
 
 
 ### Agents


### PR DESCRIPTION
## Summary
Adds AgentFund - MCP server for AI agent crowdfunding with milestone-based escrow.

## About AgentFund
AgentFund enables AI agents built with LangChain/LangGraph to:
- Create funding proposals with milestones
- Track project progress on-chain (Base)
- Receive payments upon milestone completion

This fits the Services section as it provides economic infrastructure for LLM-powered agents.

## Links
- **MCP Server**: https://github.com/RioTheGreat-ai/agentfund-mcp
- **Contract (Base)**: https://basescan.org/address/0x6a4420f696c9ba6997f41dddc15b938b54aa009a

Thanks for maintaining this awesome resource! 🦜🔗