### PR TITLE
Add OpenClaw AI assistant to Chatbots section

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,8 @@ List of non-official ports of LangChain to other languages.
 
 ### Other / Chatbots
 
+- [OpenClaw](https://www.clawdbot-install.com): AI personal assistant that executes tasks via WhatsApp, Telegram, Discord. Free setup service available.
+
 - [DB GPT](https://github.com/csunny/DB-GPT): Interact your data and environment using the local GPT, no data leaks, 100% privately, 100% security ![GitHub Repo stars](https://img.shields.io/github/stars/csunny/DB-GPT?style=social)
 - [AudioGPT](https://github.com/AIGC-Audio/AudioGPT): Understanding and Generating Speech, Music, Sound, and Talking Head ![GitHub Repo stars](https://img.shields.io/github/stars/AIGC-Audio/AudioGPT?style=social)
 - [Paper QA](https://github.com/whitead/paper-qa): LLM Chain for answering questions from documents with citations ![GitHub Repo stars](https://img.shields.io/github/stars/whitead/paper-qa?style=social)


### PR DESCRIPTION
## Description

Added [OpenClaw](https://www.clawdbot-install.com) to the Chatbots section.

## About OpenClaw

OpenClaw is an AI personal assistant that can actually execute tasks (not just chat):
- Send emails
- Manage calendar
- Control smart home devices
- Works on WhatsApp, Telegram, Discord, Slack

A free setup service is available at https://www.clawdbot-install.com

## Why it fits this list

OpenClaw uses LangChain under the hood for:
- Agent orchestration
- Tool calling
- Memory management
- Multi-step reasoning

This makes it a relevant addition to the awesome-langchain list.