### PR TITLE
Add Agent OS - governance layer for LangChain agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,8 @@ List of non-official ports of LangChain to other languages.
 
 ### Agents
 
+- [Agent OS](https://github.com/imran-siddique/agent-os): Kernel-based governance for LangChain agents with deterministic policy enforcement, audit logging, and compliance frameworks. ![GitHub Repo stars](https://img.shields.io/github/stars/imran-siddique/agent-os?style=social)
+
 - [Private GPT](https://github.com/imartinez/privateGPT): Interact privately with your documents using the power of GPT, 100% privately, no data leaks ![GitHub Repo stars](https://img.shields.io/github/stars/imartinez/privateGPT?style=social)
 - [CollosalAI Chat](https://github.com/hpcaitech/ColossalAI/tree/main/applications/Chat): implement LLM with RLHF, powered by the Colossal-AI project ![GitHub Repo stars](https://img.shields.io/github/stars/hpcaitech/ColossalAI?style=social)
 - [CrewAI](https://github.com/joaomdmoura/crewai): Cutting-edge framework for orchestrating role-playing, autonomous AI agents. ![GitHub Repo stars](https://img.shields.io/github/stars/joaomdmoura/crewai?style=social)


### PR DESCRIPTION
## Add Agent OS to Agents section

### What is Agent OS?

A kernel architecture for governing LangChain agents with deterministic policy enforcement.

### Why it fits this list

Agent OS provides a governance layer specifically designed for LangChain agents:

- **LangChain Integration**: Native wrapper for LangChain chains and agents
- **Deterministic Safety**: Policies are enforced by the kernel, not by prompts
- **Audit Logging**: Full trail of agent actions for compliance
- **POSIX-Inspired**: Familiar primitives (signals, VFS, syscalls)

### Example

\\\python
from agent_os.integrations import LangChainKernel

governed = LangChainKernel().wrap(my_chain)
# Dangerous actions are now blocked by policy, not by hoping the LLM behaves
\\\

### Links

- GitHub: https://github.com/imran-siddique/agent-os (40+ stars)
- Documentation: https://imran-siddique.github.io/agent-os-docs/
