### PR TITLE
Add Agent OS to Agents section

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ List of non-official ports of LangChain to other languages.
 - [Autonomous HR Chatbot](https://github.com/stepanogil/autonomous-hr-chatbot): An autonomous agent that can answer HR related queries autonomously using the tools it has on hand ![GitHub Repo stars](https://img.shields.io/github/stars/stepanogil/autonomous-hr-chatbot?style=social)
 - [BlockAGI](https://github.com/blockpipe/blockagi): BlockAGI conducts iterative, domain-specific research, and outputs detailed narrative reports to showcase its findings ![GitHub Repo stars](https://img.shields.io/github/stars/blockpipe/blockagi?style=social)
 - [waggledance.ai](https://github.com/agi-merge/waggle-dance): An opinionated, concurrent system of AI Agents. It implements Plan-Validate-Solve with data and tools for general goal-solving. ![GitHub Repo stars](https://img.shields.io/github/stars/agi-merge/waggle-dance?style=social)
+- [Agent OS](https://github.com/imran-siddique/agent-os): Governance layer for LangChain agents with deterministic policy enforcement, action interception, and audit logging. ![GitHub Repo stars](https://img.shields.io/github/stars/imran-siddique/agent-os?style=social)
 
 
 ### Templates


### PR DESCRIPTION
## Add Agent OS

Adds Agent OS to the Agents section - a governance layer for LangChain agents.

### What is Agent OS?

[Agent OS](https://github.com/imran-siddique/agent-os) provides deterministic policy enforcement for LangChain agents:

- **Policy Enforcement**: Block dangerous actions before they execute (not via prompts)
- **Action Interception**: Wrap LangChain chains/agents with governance checks
- **Audit Logging**: Full trail of agent actions for debugging and compliance
- **Native LangChain Integration**: Works as a wrapper around existing chains

### Example Usage

\\\python
from agent_os.integrations import LangChainKernel

# Wrap your existing LangChain chain with governance
governed_chain = LangChainKernel().wrap(my_langchain_chain)

# Dangerous actions are now blocked by policy
\\\

### Added Value

Complements existing agents in the list by providing a safety/governance layer that can wrap any LangChain agent.

Thanks for maintaining this awesome list! 🙏