### PR TITLE
Add langchain-agentmesh - Trust layer for LangChain agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ List of non-official ports of LangChain to other languages.
 - [promptfoo](https://github.com/promptfoo/promptfoo): Test and evaluate LLM applications built with LangChain. Compare prompts, models, and RAG pipelines. Red team with multi-turn attacks and catch security vulnerabilities in CI/CD. ![GitHub Repo stars](https://img.shields.io/github/stars/promptfoo/promptfoo?style=social)
 - [far-search-tool](https://github.com/blueskylineassets/far-search-tool): LangChain tool for semantic search over Federal Acquisition Regulations (FAR). Enables AI agents to query U.S. government contracting rules and compliance requirements. ![GitHub Repo stars](https://img.shields.io/github/stars/blueskylineassets/far-search-tool?style=social)
 - [Tenuo](https://github.com/tenuo-ai/tenuo): Capability-based authorization for AI agents. Task-scoped tokens with offline verification, proof-of-possession binding, and native LangChain/LangGraph integration. ![GitHub Repo stars](https://img.shields.io/github/stars/tenuo-ai/tenuo?style=social)
+- [langchain-agentmesh](https://github.com/imran-siddique/agent-mesh/tree/master/packages/langchain-agentmesh): Trust layer for LangChain agents with Ed25519 cryptographic identity, peer verification, trust-gated tools, and audit logging. ![GitHub Repo stars](https://img.shields.io/github/stars/imran-siddique/agent-mesh?style=social)
 
 
 ### Agents


### PR DESCRIPTION
## Summary

Adds [langchain-agentmesh](https://github.com/imran-siddique/agent-mesh/tree/master/packages/langchain-agentmesh) to the Services section.

## What it does

AgentMesh provides a **trust layer** for LangChain agents:

- **Ed25519 Cryptographic Identity** - Real cryptographic signing/verification using CMVK scheme
- **Peer Verification** - Verify agent identity before interaction with trust scoring  
- **Trust-Gated Tools** - Tools that require minimum trust scores and capabilities
- **Audit Logging** - TrustCallbackHandler tracks all LLM/chain/tool operations

## Installation

\\\ash
pip install langchain-agentmesh
\\\

## Why it fits

Similar to existing security tools in the list (Agentic Radar, Tenuo, promptfoo), langchain-agentmesh addresses the growing need for **agent identity and trust verification** in multi-agent LangChain applications.

## Links

- Package: [langchain-agentmesh on GitHub](https://github.com/imran-siddique/agent-mesh/tree/master/packages/langchain-agentmesh)
- Parent project: [AgentMesh](https://github.com/imran-siddique/agent-mesh) - The secure nervous system for cloud-native agent ecosystems