### PR TITLE
Add MOSS LangChain Integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ List of non-official ports of LangChain to other languages.
 - [promptfoo](https://github.com/promptfoo/promptfoo): Test and evaluate LLM applications built with LangChain. Compare prompts, models, and RAG pipelines. Red team with multi-turn attacks and catch security vulnerabilities in CI/CD. ![GitHub Repo stars](https://img.shields.io/github/stars/promptfoo/promptfoo?style=social)
 - [far-search-tool](https://github.com/blueskylineassets/far-search-tool): LangChain tool for semantic search over Federal Acquisition Regulations (FAR). Enables AI agents to query U.S. government contracting rules and compliance requirements. ![GitHub Repo stars](https://img.shields.io/github/stars/blueskylineassets/far-search-tool?style=social)
 - [Tenuo](https://github.com/tenuo-ai/tenuo): Capability-based authorization for AI agents. Task-scoped tokens with offline verification, proof-of-possession binding, and native LangChain/LangGraph integration. ![GitHub Repo stars](https://img.shields.io/github/stars/tenuo-ai/tenuo?style=social)
-- [MOSS LangChain](https://github.com/mosscomputing/moss-langchain): Cryptographic signing for LangChain agent outputs. Add tamper-proof audit trails with ML-DSA-44 post-quantum signatures. Sign tool calls, chain results, and messages. ![GitHub Repo stars](https://img.shields.io/github/stars/mosscomputing/moss-langchain?style=social)
+- [MOSS LangChain](https://pypi.org/project/moss-langchain/): Cryptographic signing for LangChain agent outputs. Add tamper-proof audit trails with ML-DSA-44 post-quantum signatures. Sign tool calls, chain results, and messages. ![GitHub Repo stars](https://img.shields.io/github/stars/moss-langchain?style=social)
 
 
 ### Agents


### PR DESCRIPTION
## What is MOSS LangChain?

moss-langchain provides cryptographic signing for LangChain agent outputs using ML-DSA-44 post-quantum signatures.

## Why it belongs here

- Sign tool calls, chain results, and messages
- Tamper-proof audit trails for LangChain applications
- Offline verification without API calls
- Post-quantum secure (NIST FIPS 204)

## Installation

```bash
pip install moss-langchain
```

## Links

- PyPI: https://pypi.org/project/moss-langchain/
- Website: https://mosscomputing.com