### PR TITLE
Add MolTrust — Trust Infrastructure for AI Agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ List of non-official ports of LangChain to other languages.
 - [promptfoo](https://github.com/promptfoo/promptfoo): Test and evaluate LLM applications built with LangChain. Compare prompts, models, and RAG pipelines. Red team with multi-turn attacks and catch security vulnerabilities in CI/CD. ![GitHub Repo stars](https://img.shields.io/github/stars/promptfoo/promptfoo?style=social)
 - [far-search-tool](https://github.com/blueskylineassets/far-search-tool): LangChain tool for semantic search over Federal Acquisition Regulations (FAR). Enables AI agents to query U.S. government contracting rules and compliance requirements. ![GitHub Repo stars](https://img.shields.io/github/stars/blueskylineassets/far-search-tool?style=social)
 - [Tenuo](https://github.com/tenuo-ai/tenuo): Capability-based authorization for AI agents. Task-scoped tokens with offline verification, proof-of-possession binding, and native LangChain/LangGraph integration. ![GitHub Repo stars](https://img.shields.io/github/stars/tenuo-ai/tenuo?style=social)
+- [MolTrust](https://github.com/MoltyCel/moltrust-sdk): Trust infrastructure for AI agents — identity verification (W3C DIDs), reputation scoring, and Verifiable Credentials with Ed25519 signatures and Base blockchain anchoring. `pip install moltrust` ![GitHub Repo stars](https://img.shields.io/github/stars/MoltyCel/moltrust-sdk?style=social)
 
 
 ### Agents


### PR DESCRIPTION
## Summary

- Adds [MolTrust](https://github.com/MoltyCel/moltrust-sdk) to the **Tools > Services** section
- MolTrust provides trust infrastructure for AI agents:
  - **Identity Verification** — W3C DID-based decentralized identities for agents
  - **Reputation Scoring** — Peer-to-peer trust ratings between agents
  - **W3C Verifiable Credentials** — Ed25519-signed credentials with Base blockchain anchoring

## Links

- SDK: `pip install moltrust`
- API Docs: https://api.moltrust.ch/docs
- GitHub: https://github.com/MoltyCel/moltrust-sdk
- Website: https://moltrust.ch