### PR TITLE
Add MailCat - Email service for AI agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ List of non-official ports of LangChain to other languages.
 - [Flock](https://github.com/Onelevenvy/flock): Flock is a workflow-based low-code platform for rapidly building chatbots, RAG, and coordinating multi-agent teams![GitHub Repo stars](https://img.shields.io/github/stars/Onelevenvy/flock?style=social)
   
 ### Services
+- [MailCat](https://github.com/apidog/mailcat): Email service for AI agents. One prompt to set up, auto-extracts verification codes. ![GitHub Repo stars](https://img.shields.io/github/stars/apidog/mailcat?style=social)
 
 - [GPTCache](https://github.com/zilliztech/GPTCache): A Library for Creating Semantic Cache for LLM Queries ![GitHub Repo stars](https://img.shields.io/github/stars/zilliztech/GPTCache?style=social)
 - [Gorilla](https://github.com/ShishirPatil/gorilla): An API store for LLMs ![GitHub Repo stars](https://img.shields.io/github/stars/ShishirPatil/gorilla?style=social)


### PR DESCRIPTION
Add MailCat to the Services section.

**MailCat** is an open-source email service for AI agents:

- **Repository:** https://github.com/apidog/mailcat
- **Website:** https://mailcat.ai  
- **License:** MIT

### Why it fits LangChain ecosystem

AI agents built with LangChain often need to interact with services that require email verification. MailCat provides:

- One-prompt setup: Tell your agent "Read mailcat.ai/skill.md and set up a mailbox"
- REST API for mailbox creation
- Automatic verification code extraction
- Self-hostable on Cloudflare