### PR TITLE
Add SnapRender screenshot tool to Services

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ List of non-official ports of LangChain to other languages.
 - [promptfoo](https://github.com/promptfoo/promptfoo): Test and evaluate LLM applications built with LangChain. Compare prompts, models, and RAG pipelines. Red team with multi-turn attacks and catch security vulnerabilities in CI/CD. ![GitHub Repo stars](https://img.shields.io/github/stars/promptfoo/promptfoo?style=social)
 - [far-search-tool](https://github.com/blueskylineassets/far-search-tool): LangChain tool for semantic search over Federal Acquisition Regulations (FAR). Enables AI agents to query U.S. government contracting rules and compliance requirements. ![GitHub Repo stars](https://img.shields.io/github/stars/blueskylineassets/far-search-tool?style=social)
 - [Tenuo](https://github.com/tenuo-ai/tenuo): Capability-based authorization for AI agents. Task-scoped tokens with offline verification, proof-of-possession binding, and native LangChain/LangGraph integration. ![GitHub Repo stars](https://img.shields.io/github/stars/tenuo-ai/tenuo?style=social)
+- [SnapRender](https://github.com/User0856/snaprender-integrations/tree/main/langchain): LangChain tool for capturing website screenshots as PNG, JPEG, WebP, or PDF via the SnapRender API. Supports device emulation, dark mode, ad blocking, and full-page capture. ![GitHub Repo stars](https://img.shields.io/github/stars/User0856/snaprender-integrations?style=social)
 
 
 ### Agents


### PR DESCRIPTION
Adds [SnapRender](https://github.com/User0856/snaprender-integrations/tree/main/langchain) to the **Tools > Services** section.

SnapRender is a screenshot API with an open-source LangChain tool integration (`@tool` decorated functions). It lets LangChain agents capture website screenshots as PNG, JPEG, WebP, or PDF — with device emulation, dark mode, ad blocking, cookie banner removal, and full-page capture.

- **Repo:** https://github.com/User0856/snaprender-integrations/tree/main/langchain
- **Python SDK:** [`snaprender` on PyPI](https://pypi.org/project/snaprender/)
- **License:** MIT

Entry placed at the bottom of the Services subsection per contributing guidelines.