### PR TITLE
Add Veritensor to the Services

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ List of non-official ports of LangChain to other languages.
 - [promptfoo](https://github.com/promptfoo/promptfoo): Test and evaluate LLM applications built with LangChain. Compare prompts, models, and RAG pipelines. Red team with multi-turn attacks and catch security vulnerabilities in CI/CD. ![GitHub Repo stars](https://img.shields.io/github/stars/promptfoo/promptfoo?style=social)
 - [far-search-tool](https://github.com/blueskylineassets/far-search-tool): LangChain tool for semantic search over Federal Acquisition Regulations (FAR). Enables AI agents to query U.S. government contracting rules and compliance requirements. ![GitHub Repo stars](https://img.shields.io/github/stars/blueskylineassets/far-search-tool?style=social)
 - [Tenuo](https://github.com/tenuo-ai/tenuo): Capability-based authorization for AI agents. Task-scoped tokens with offline verification, proof-of-possession binding, and native LangChain/LangGraph integration. ![GitHub Repo stars](https://img.shields.io/github/stars/tenuo-ai/tenuo?style=social)
-
+- [Veritensor](https://github.com/arsbr/Veritensor) - Native security wrappers for LangChain DocumentLoaders to block prompt injections, stealth attacks, and PII leaks during RAG data ingestion. ![GitHub Repo stars](https://img.shields.io/github/stars/arsbr/Veritensor?style=social)
 
 ### Agents
 


### PR DESCRIPTION
Hi @sbusso,

I’d like to resubmit Veritensor, this time highlighting its native LangChain integration designed specifically to secure LangChain RAG pipelines against Data Poisoning and Prompt Injections during the ingestion phase.

Veritensor now provides a `SecureLangChainLoader` wrapper that seamlessly integrates with any LangChain `BaseLoader`. It intercepts and sanitizes documents before they are chunked and embedded into vector stores, preventing malicious payloads (like hidden CSS prompt injections or PII leaks) from compromising the LLM.

Here is how the LangChain integration works in practice:

```Python
from langchain_community.document_loaders import PyPDFLoader
from veritensor.integrations.langchain_guard import SecureLangChainLoader

# 1. Take any standard LangChain document loader
unsafe_loader = PyPDFLoader("user_upload_resume.pdf")

# 2. Wrap it in the Veritensor Guard
secure_loader = SecureLangChainLoader(
    file_path="user_upload_resume.pdf", 
    base_loader=unsafe_loader,
    strict_mode=True # Automatically raises an error if threats are found
)

# 3. Safely load LangChain Document objects
# Scans for prompt injections, stealth text, and PII before returning data
docs = secure_loader.load()
```

Since LangChain is heavily used for RAG, data ingestion security is a massive pain point for developers. Veritensor solves this directly within the LangChain ecosystem.

Proposed entry for the README.md (under Services):
- [Veritensor](https://github.com/arsbr/Veritensor) - Native security wrappers for LangChain DocumentLoaders to block prompt injections, stealth attacks, and PII leaks during RAG data ingestion. ![GitHub Repo stars](https://img.shields.io/github/stars/arsbr/Veritensor?style=social)


Repo: https://github.com/arsbr/Veritensor
License: Apache 2.0

Thanks!