### PR TITLE
Add Agent OS to Agents section

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,8 @@ List of non-official ports of LangChain to other languages.
 - [waggledance.ai](https://github.com/agi-merge/waggle-dance): An opinionated, concurrent system of AI Agents. It implements Plan-Validate-Solve with data and tools for general goal-solving. ![GitHub Repo stars](https://img.shields.io/github/stars/agi-merge/waggle-dance?style=social)
 
 
+- [Agent OS](https://github.com/imran-siddique/agent-os): A governance kernel for AI agents providing policy enforcement, trust scoring, and circuit breakers. Includes LangGraph integration via [langgraph-trust](https://pypi.org/project/langgraph-trust/). ![GitHub Repo stars](https://img.shields.io/github/stars/imran-siddique/agent-os?style=social)
+
 ### Templates
 
 - [AI](https://github.com/vercel-labs/ai): Vercel template to build AI-powered applications with React, Svelte, and Vue, first class support for LangChain ![GitHub Repo stars](https://img.shields.io/github/stars/vercel-labs/ai?style=social)


### PR DESCRIPTION
## Add Agent OS to Agents section

[Agent OS](https://github.com/imran-siddique/agent-os) is a governance kernel for AI agents providing policy enforcement, trust scoring, and circuit breakers.

### Why it belongs in awesome-langchain
- Has an official **LangGraph integration** via [langgraph-trust](https://pypi.org/project/langgraph-trust/) on PyPI
- Provides governance primitives (policy enforcement, trust scoring, circuit breakers) for LangChain/LangGraph agents
- Open source (MIT), 1,680+ tests, <0.1ms p99 latency overhead
- Integrated with LlamaIndex, Dify, Microsoft Agent-Lightning, OpenAI Agents SDK
- Covers 8/10 OWASP Agentic Top 10 security risks

### Links
- GitHub: https://github.com/imran-siddique/agent-os
- LangGraph integration: https://pypi.org/project/langgraph-trust/
- Docs: https://imran-siddique.github.io/agent-os-docs/