### PR TITLE
Add CallStack

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ List of non-official ports of LangChain to other languages.
 - [far-search-tool](https://github.com/blueskylineassets/far-search-tool): LangChain tool for semantic search over Federal Acquisition Regulations (FAR). Enables AI agents to query U.S. government contracting rules and compliance requirements. ![GitHub Repo stars](https://img.shields.io/github/stars/blueskylineassets/far-search-tool?style=social)
 - [Tenuo](https://github.com/tenuo-ai/tenuo): Capability-based authorization for AI agents. Task-scoped tokens with offline verification, proof-of-possession binding, and native LangChain/LangGraph integration. ![GitHub Repo stars](https://img.shields.io/github/stars/tenuo-ai/tenuo?style=social)
 - [Veritensor](https://github.com/arsbr/Veritensor) - Native security wrappers for LangChain DocumentLoaders to block prompt injections, stealth attacks, and PII leaks during RAG data ingestion. ![GitHub Repo stars](https://img.shields.io/github/stars/arsbr/Veritensor?style=social)
+- [CallStack](https://github.com/alenmanjgafic/callstack): Open-source LLM API gateway with unified API for OpenAI, Anthropic, Gemini, and DeepSeek. Automatic failover, cost tracking, rate limiting, and response caching. ![GitHub Repo stars](https://img.shields.io/github/stars/alenmanjgafic/callstack?style=social)
 
 ### Agents
 


### PR DESCRIPTION
## Add CallStack to Services

[CallStack](https://github.com/alenmanjgafic/callstack) is an open-source LLM API gateway that provides a unified API for multiple LLM providers (OpenAI, Anthropic, Gemini, DeepSeek). It includes automatic failover between providers, cost tracking, rate limiting, and response caching.

It fits the **Services** section as an infrastructure tool that complements LangChain workflows by handling the underlying API routing, resilience, and cost management layer.