### PR TITLE
Add AgentWard to security tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ List of non-official ports of LangChain to other languages.
 - [far-search-tool](https://github.com/blueskylineassets/far-search-tool): LangChain tool for semantic search over Federal Acquisition Regulations (FAR). Enables AI agents to query U.S. government contracting rules and compliance requirements. ![GitHub Repo stars](https://img.shields.io/github/stars/blueskylineassets/far-search-tool?style=social)
 - [Tenuo](https://github.com/tenuo-ai/tenuo): Capability-based authorization for AI agents. Task-scoped tokens with offline verification, proof-of-possession binding, and native LangChain/LangGraph integration. ![GitHub Repo stars](https://img.shields.io/github/stars/tenuo-ai/tenuo?style=social)
 - [Veritensor](https://github.com/arsbr/Veritensor) - Native security wrappers for LangChain DocumentLoaders to block prompt injections, stealth attacks, and PII leaks during RAG data ingestion. ![GitHub Repo stars](https://img.shields.io/github/stars/arsbr/Veritensor?style=social)
+- [AgentWard](https://github.com/agentward-ai/agentward): Permission control plane for AI agents. Scans tool definitions (including LangChain), enforces least-privilege YAML policies on every tool call, classifies sensitive data, and generates compliance audit trails. ![GitHub Repo stars](https://img.shields.io/github/stars/agentward-ai/agentward?style=social)
 
 ### Agents
 


### PR DESCRIPTION
Adding AgentWard to the security tools section alongside Agentic Radar, promptfoo, Tenuo, and Veritensor.

AgentWard scans tool definitions (including LangChain tools), enforces least-privilege YAML policies on every tool call at the MCP protocol level, classifies sensitive data, and generates compliance audit trails.

https://github.com/agentward-ai/agentward