### PR TITLE
Add APIClaw - API layer for AI agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ List of non-official ports of LangChain to other languages.
 
 - [GPTCache](https://github.com/zilliztech/GPTCache): A Library for Creating Semantic Cache for LLM Queries ![GitHub Repo stars](https://img.shields.io/github/stars/zilliztech/GPTCache?style=social)
 - [Gorilla](https://github.com/ShishirPatil/gorilla): An API store for LLMs ![GitHub Repo stars](https://img.shields.io/github/stars/ShishirPatil/gorilla?style=social)
+- [APIClaw](https://github.com/nordsym/apiclaw): The API layer for AI agents. 22,000+ APIs indexed, semantic discovery, and Direct Call execution via MCP. Works with any MCP-compatible agent. ![GitHub Repo stars](https://img.shields.io/github/stars/nordsym/apiclaw?style=social)
 - [LlamaHub](https://github.com/emptycrown/llama-hub): a library of data loaders for LLMs made by the community ![GitHub Repo stars](https://img.shields.io/github/stars/emptycrown/llama-hub?style=social)
 - [Auto-evaluator](https://github.com/PineappleExpress808/auto-evaluator): a lightweight evaluation tool for question-answering using Langchain ![GitHub Repo stars](https://img.shields.io/github/stars/PineappleExpress808/auto-evaluator?style=social)
 - [Langchain visualizer](https://github.com/amosjyng/langchain-visualizer): visualization and debugging tool for LangChain workflows ![GitHub Repo stars](https://img.shields.io/github/stars/amosjyng/langchain-visualizer?style=social)


### PR DESCRIPTION
Adding APIClaw to the Services section.

## What is APIClaw?
The API layer for AI agents — infrastructure, not just another tool.

- **22,000+ APIs indexed** — Semantic discovery by capability, not keywords
- **18 Direct Call providers** — Execute without managing API keys  
- **MCP native** — Works with LangChain, Claude, and any MCP-compatible agent
- **Built for the agentic era** — The rails your agents run on

## Links
- https://github.com/nordsym/apiclaw
- https://www.npmjs.com/package/@nordsym/apiclaw