### PR TITLE
Add StripFeed – URL to Markdown API for LLM/RAG pipelines

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ List of non-official ports of LangChain to other languages.
 - [far-search-tool](https://github.com/blueskylineassets/far-search-tool): LangChain tool for semantic search over Federal Acquisition Regulations (FAR). Enables AI agents to query U.S. government contracting rules and compliance requirements. ![GitHub Repo stars](https://img.shields.io/github/stars/blueskylineassets/far-search-tool?style=social)
 - [Tenuo](https://github.com/tenuo-ai/tenuo): Capability-based authorization for AI agents. Task-scoped tokens with offline verification, proof-of-possession binding, and native LangChain/LangGraph integration. ![GitHub Repo stars](https://img.shields.io/github/stars/tenuo-ai/tenuo?style=social)
 - [Veritensor](https://github.com/arsbr/Veritensor) - Native security wrappers for LangChain DocumentLoaders to block prompt injections, stealth attacks, and PII leaks during RAG data ingestion. ![GitHub Repo stars](https://img.shields.io/github/stars/arsbr/Veritensor?style=social)
+- [StripFeed](https://github.com/StripFeed/stripfeed-js): API that converts any URL to clean Markdown for LLM and RAG pipelines. Saves 60-80% tokens vs raw HTML. TypeScript and Python SDKs, MCP server, caching, batch fetch, CSS selectors. ![GitHub Repo stars](https://img.shields.io/github/stars/StripFeed/stripfeed-js?style=social)
 
 ### Agents
 


### PR DESCRIPTION
**StripFeed** is an API that converts any URL to clean Markdown, purpose-built for LLM and RAG pipelines.

- Saves 60-80% tokens compared to feeding raw HTML to models
- TypeScript SDK ([npm](https://www.npmjs.com/package/stripfeed)) and Python SDK ([PyPI](https://pypi.org/project/stripfeed/))
- MCP server ([npm](https://www.npmjs.com/package/@stripfeed/mcp-server))
- Caching, batch fetch (up to 10 URLs), CSS selectors, token counting
- Free tier: 200 requests/month

**Links:**
- Website: https://www.stripfeed.dev
- TypeScript SDK: https://github.com/StripFeed/stripfeed-js
- Python SDK: https://github.com/StripFeed/stripfeed-python
- MCP Server: https://github.com/StripFeed/mcp-server

Added to the **Services** section (bottom of list, per contributing guidelines).