### PR TITLE
Add langchain-insumer (on-chain verification tools)

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ List of non-official ports of LangChain to other languages.
 - [far-search-tool](https://github.com/blueskylineassets/far-search-tool): LangChain tool for semantic search over Federal Acquisition Regulations (FAR). Enables AI agents to query U.S. government contracting rules and compliance requirements. ![GitHub Repo stars](https://img.shields.io/github/stars/blueskylineassets/far-search-tool?style=social)
 - [Tenuo](https://github.com/tenuo-ai/tenuo): Capability-based authorization for AI agents. Task-scoped tokens with offline verification, proof-of-possession binding, and native LangChain/LangGraph integration. ![GitHub Repo stars](https://img.shields.io/github/stars/tenuo-ai/tenuo?style=social)
 - [Veritensor](https://github.com/arsbr/Veritensor) - Native security wrappers for LangChain DocumentLoaders to block prompt injections, stealth attacks, and PII leaks during RAG data ingestion. ![GitHub Repo stars](https://img.shields.io/github/stars/arsbr/Veritensor?style=social)
+- [langchain-insumer](https://github.com/douglasborthwick-crypto/langchain-insumer): 25 LangChain tools for privacy-preserving on-chain verification across 32 blockchains. Verify token balances, NFT ownership, EAS credentials, and Farcaster IDs. Returns ECDSA-signed boolean attestations — no Web3 libraries needed. Covers wallet trust profiles, merchant onboarding, and ACP/UCP commerce protocol integration. ![GitHub Repo stars](https://img.shields.io/github/stars/douglasborthwick-crypto/langchain-insumer?style=social)
 
 ### Agents
 


### PR DESCRIPTION
## What it does
langchain-insumer provides 25 LangChain tools for privacy-preserving on-chain verification across 32 blockchains (30 EVM + Solana + XRPL). AI agents can verify token balances, NFT ownership, EAS credentials, and Farcaster IDs — receiving ECDSA-signed boolean attestations without exposing wallet balances or requiring Web3 libraries.

## Why it belongs here
No existing LangChain blockchain integration focuses on verification/attestation. Every other tool returns raw data. langchain-insumer returns a cryptographic proof that a third party can verify offline — enabling agent-to-agent trust decisions.

Used by DJD Agent Score (Coinbase x402 ecosystem).

- PyPI: https://pypi.org/project/langchain-insumer/
- GitHub: https://github.com/douglasborthwick-crypto/langchain-insumer