### PR TITLE
Add JARVIS — self-hosted AI assistant platform with LangGraph

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,6 +193,7 @@ List of non-official ports of LangChain to other languages.
 - [PersonalityChatbot](https://github.com/btrcm00/chatbot-with-langchain): Langchain chatbot for chat with personality using Langchain🦜 | LangSmith | MongoDB. ![GitHub Repo stars](https://img.shields.io/github/stars/btrcm00/chatbot-with-langchain?style=social)
 - [XAgent](https://github.com/OpenBMB/XAgent): An Autonomous LLM Agent for Complex Task Solving ![GitHub Repo stars](https://img.shields.io/github/stars/OpenBMB/XAgent?style=social)
 - [MemFree](https://github.com/memfreeme/memfree) - Open Source Hybrid AI Search Engine, Instantly Get Accurate Answers from the Internet, Bookmarks, Notes, and Docs. Support One-Click Deployment. ![GitHub Repo stars](https://img.shields.io/github/stars/memfreeme/memfree?style=social)
+- [JARVIS](https://github.com/hyhmrright/JARVIS): Self-hosted AI assistant platform with RAG, multi-LLM support (DeepSeek/OpenAI/Anthropic), plugin SDK, and multi-channel gateway (Slack/Discord/Telegram). Built with FastAPI and LangGraph. ![GitHub Repo stars](https://img.shields.io/github/stars/hyhmrright/JARVIS?style=social)
 
 ## Learn
 


### PR DESCRIPTION
## Addition

Adding [JARVIS](https://github.com/hyhmrright/JARVIS) to the **Other / Chatbots** section.

**What is JARVIS?**

Self-hosted AI assistant platform built on LangGraph (ReAct agent loop) with:
- RAG knowledge base (Qdrant vector DB + OpenAI embeddings)
- Multi-LLM support: DeepSeek / OpenAI / Anthropic / ZhipuAI GLM
- Plugin SDK — extend with pure Python plugins
- Multi-channel gateway: Slack · Discord · Telegram · Feishu · WhatsApp · Webhook
- RBAC (user / admin / superadmin roles)
- Full observability: Prometheus + Grafana + Loki
- One-command deploy: `docker compose up -d`

**Tech stack:** FastAPI · LangGraph · LangChain · Vue 3 · PostgreSQL · Qdrant · Redis · MinIO

**License:** MIT | **Stars:** growing | **Latest release:** v0.4.0
