### PR TITLE
Add FinSight – multi-agent financial research platform built with LangGraph

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,7 @@ List of non-official ports of LangChain to other languages.
 - [XAgent](https://github.com/OpenBMB/XAgent): An Autonomous LLM Agent for Complex Task Solving ![GitHub Repo stars](https://img.shields.io/github/stars/OpenBMB/XAgent?style=social)
 - [MemFree](https://github.com/memfreeme/memfree) - Open Source Hybrid AI Search Engine, Instantly Get Accurate Answers from the Internet, Bookmarks, Notes, and Docs. Support One-Click Deployment. ![GitHub Repo stars](https://img.shields.io/github/stars/memfreeme/memfree?style=social)
 - [JARVIS](https://github.com/hyhmrright/JARVIS): Self-hosted AI assistant platform with RAG, multi-LLM support (DeepSeek/OpenAI/Anthropic), plugin SDK, and multi-channel gateway (Slack/Discord/Telegram). Built with FastAPI and LangGraph. ![GitHub Repo stars](https://img.shields.io/github/stars/hyhmrright/JARVIS?style=social)
+- [FinSight](https://github.com/kkkano/FinSight): Production-grade multi-agent financial research platform with 7 specialized agents (Price, News, Fundamental, Technical, Macro, Risk, DeepSearch), hybrid RAG engine, professional dashboard, and autonomous task execution. Built with LangGraph, FastAPI, and React. ![GitHub Repo stars](https://img.shields.io/github/stars/kkkano/FinSight?style=social)
 
 ## Learn
 


### PR DESCRIPTION
## Addition

Adding [FinSight](https://github.com/kkkano/FinSight) to the **Other / Chatbots** section.

**What is FinSight?**

FinSight is a production-grade multi-agent financial research platform built on LangGraph with:
- 7 specialized research agents (Price, News, Fundamental, Technical, Macro, Risk, DeepSearch) running in parallel
- 18-node LangGraph StateGraph with adaptive routing
- Professional dashboard with 6 analytical tabs and AI insight cards
- Hybrid RAG engine (bge-m3 dense+sparse + cross-encoder reranking)
- Cross-agent conflict detection (8 comparable dimensions)
- Autonomous task execution (Workbench) with SSE streaming
- Proactive email alerts (price, news, risk schedulers)
- LLM-driven Smart Charts with ECharts

**Tech stack:** FastAPI · LangGraph · LangChain · React · PostgreSQL · pgvector · ECharts

**License:** MIT | **Live Demo:** https://finsight-ai.chat