### PR TITLE
Add Grantex to Tools > Services

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ List of non-official ports of LangChain to other languages.
 - [far-search-tool](https://github.com/blueskylineassets/far-search-tool): LangChain tool for semantic search over Federal Acquisition Regulations (FAR). Enables AI agents to query U.S. government contracting rules and compliance requirements. ![GitHub Repo stars](https://img.shields.io/github/stars/blueskylineassets/far-search-tool?style=social)
 - [Tenuo](https://github.com/tenuo-ai/tenuo): Capability-based authorization for AI agents. Task-scoped tokens with offline verification, proof-of-possession binding, and native LangChain/LangGraph integration. ![GitHub Repo stars](https://img.shields.io/github/stars/tenuo-ai/tenuo?style=social)
 - [Veritensor](https://github.com/arsbr/Veritensor) - Native security wrappers for LangChain DocumentLoaders to block prompt injections, stealth attacks, and PII leaks during RAG data ingestion. ![GitHub Repo stars](https://img.shields.io/github/stars/arsbr/Veritensor?style=social)
+- [Grantex](https://github.com/mishrasanjeev/grantex): Delegated authorization protocol for AI agents with native LangChain toolkit, JWT-based grant tokens, and scope-based access control. ![GitHub Repo stars](https://img.shields.io/github/stars/mishrasanjeev/grantex?style=social)
 
 ### Agents
 


### PR DESCRIPTION
Grantex is an open-source (Apache 2.0) delegated authorization protocol for AI agents with a native LangChain integration (@grantex/langchain).

It provides scoped, revocable permissions via signed JWTs — replacing all-or-nothing API keys for LangChain agents.

- npm: https://www.npmjs.com/package/@grantex/langchain
- GitHub: https://github.com/mishrasanjeev/grantex
- Docs: https://docs.grantex.dev/integrations/frameworks/langchain