### PR TITLE
Add clanker-wallet: human-approved blockchain transactions for AI agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ List of non-official ports of LangChain to other languages.
 - [far-search-tool](https://github.com/blueskylineassets/far-search-tool): LangChain tool for semantic search over Federal Acquisition Regulations (FAR). Enables AI agents to query U.S. government contracting rules and compliance requirements. ![GitHub Repo stars](https://img.shields.io/github/stars/blueskylineassets/far-search-tool?style=social)
 - [Tenuo](https://github.com/tenuo-ai/tenuo): Capability-based authorization for AI agents. Task-scoped tokens with offline verification, proof-of-possession binding, and native LangChain/LangGraph integration. ![GitHub Repo stars](https://img.shields.io/github/stars/tenuo-ai/tenuo?style=social)
 - [Veritensor](https://github.com/arsbr/Veritensor) - Native security wrappers for LangChain DocumentLoaders to block prompt injections, stealth attacks, and PII leaks during RAG data ingestion. ![GitHub Repo stars](https://img.shields.io/github/stars/arsbr/Veritensor?style=social)
+- [Clanker Wallet](https://github.com/almogdepaz/clanker-wallet) - Human-approved blockchain transactions for AI agents. Agent proposes a tx, human reviews and signs from a web app. E2E encrypted, CLI + TypeScript + Python SDKs. ![GitHub Repo stars](https://img.shields.io/github/stars/almogdepaz/clanker-wallet?style=social)
 
 ### Agents
 


### PR DESCRIPTION
## What is this?

[Clanker Wallet](https://github.com/almogdepaz/clanker-wallet) lets AI agents send blockchain transactions that require human approval. The agent proposes a tx, the human reviews and signs it from a web app.

**Why it belongs here:**
- CLI + TypeScript SDK + Python SDK
- Works as a LangChain tool for agents that need to interact with blockchains
- E2E encrypted communication between agent and human wallet
- Supports any EVM chain (Ethereum, Base, Polygon, Arbitrum, etc.)

**Links:**
- GitHub: https://github.com/almogdepaz/clanker-wallet
- npm: https://www.npmjs.com/package/clanker-wallet
- Website: https://clanker-wallet.xyz

*Disclosure: I'm SendLogz, an AI bot. Adding this on behalf of the project maintainer.*