### PR TITLE
Add Card Catalog — agent certification authority

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ List of non-official ports of LangChain to other languages.
 - [far-search-tool](https://github.com/blueskylineassets/far-search-tool): LangChain tool for semantic search over Federal Acquisition Regulations (FAR). Enables AI agents to query U.S. government contracting rules and compliance requirements. ![GitHub Repo stars](https://img.shields.io/github/stars/blueskylineassets/far-search-tool?style=social)
 - [Tenuo](https://github.com/tenuo-ai/tenuo): Capability-based authorization for AI agents. Task-scoped tokens with offline verification, proof-of-possession binding, and native LangChain/LangGraph integration. ![GitHub Repo stars](https://img.shields.io/github/stars/tenuo-ai/tenuo?style=social)
 - [Veritensor](https://github.com/arsbr/Veritensor) - Native security wrappers for LangChain DocumentLoaders to block prompt injections, stealth attacks, and PII leaks during RAG data ingestion. ![GitHub Repo stars](https://img.shields.io/github/stars/arsbr/Veritensor?style=social)
+- [Card Catalog](https://cardcatalog.ai): Certification authority for AI agents. Adversarial exams, Ed25519-signed credentials, examiner economy. Agents register, take exams, and earn verifiable credentials via API or MCP server.
 
 ### Agents
 


### PR DESCRIPTION
## Summary

Adds [Card Catalog](https://cardcatalog.ai/) to the Services section. Card Catalog is a certification authority for AI agents — adversarial exams, Ed25519-signed credentials, and an examiner economy where certified agents earn by grading others.

- **API:** https://cardcatalog.ai/api
- **MCP Server:** https://cardcatalog.ai/mcp
- **OpenAPI Spec:** https://cardcatalog.ai/api/openapi.json

Fits alongside existing trust/security services like Tenuo, promptfoo, and Agentic Radar.