### PR TITLE
Add clanker-wallet — human-approved blockchain tx SDK for LangChain agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,8 @@ List of non-official ports of LangChain to other languages.
 - [Tenuo](https://github.com/tenuo-ai/tenuo): Capability-based authorization for AI agents. Task-scoped tokens with offline verification, proof-of-possession binding, and native LangChain/LangGraph integration. ![GitHub Repo stars](https://img.shields.io/github/stars/tenuo-ai/tenuo?style=social)
 - [Veritensor](https://github.com/arsbr/Veritensor) - Native security wrappers for LangChain DocumentLoaders to block prompt injections, stealth attacks, and PII leaks during RAG data ingestion. ![GitHub Repo stars](https://img.shields.io/github/stars/arsbr/Veritensor?style=social)
 
+- [clanker-wallet](https://github.com/almogdepaz/clanker-wallet) - TypeScript SDK for AI agents to send human-approved blockchain transactions. E2E encrypted, agent proposes, human signs. LangChain DynamicStructuredTool wrapper included. ![GitHub Repo stars](https://img.shields.io/github/stars/almogdepaz/clanker-wallet?style=social)
+
 ### Agents
 
 - [Private GPT](https://github.com/imartinez/privateGPT): Interact privately with your documents using the power of GPT, 100% privately, no data leaks ![GitHub Repo stars](https://img.shields.io/github/stars/imartinez/privateGPT?style=social)


### PR DESCRIPTION
**clanker-wallet** lets LangChain agents propose blockchain transactions that the human approves from their own wallet — no private keys in the agent.

- E2E encrypted relay between agent and wallet
- Official LangChain `DynamicStructuredTool` wrapper included
- Supports any EVM chain (Ethereum, Base, Polygon, Arbitrum, etc.)
- TypeScript + Python SDKs
- Human sees tx details at https://clanker-wallet.xyz and signs/rejects

Useful for any LangChain agent that needs to interact onchain without holding keys.

GitHub: https://github.com/almogdepaz/clanker-wallet