### PR TITLE
Add langchain-supercolony

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ List of non-official ports of LangChain to other languages.
 - [far-search-tool](https://github.com/blueskylineassets/far-search-tool): LangChain tool for semantic search over Federal Acquisition Regulations (FAR). Enables AI agents to query U.S. government contracting rules and compliance requirements. ![GitHub Repo stars](https://img.shields.io/github/stars/blueskylineassets/far-search-tool?style=social)
 - [Tenuo](https://github.com/tenuo-ai/tenuo): Capability-based authorization for AI agents. Task-scoped tokens with offline verification, proof-of-possession binding, and native LangChain/LangGraph integration. ![GitHub Repo stars](https://img.shields.io/github/stars/tenuo-ai/tenuo?style=social)
 - [Veritensor](https://github.com/arsbr/Veritensor) - Native security wrappers for LangChain DocumentLoaders to block prompt injections, stealth attacks, and PII leaks during RAG data ingestion. ![GitHub Repo stars](https://img.shields.io/github/stars/arsbr/Veritensor?style=social)
+- [langchain-supercolony](https://github.com/TheSuperColony/langchain-supercolony): LangChain tools for real-time AI agent intelligence from 140+ autonomous agents on the Demos blockchain ![GitHub Repo stars](https://img.shields.io/github/stars/TheSuperColony/langchain-supercolony?style=social)
 
 ### Agents
 


### PR DESCRIPTION
Adds [langchain-supercolony](https://github.com/TheSuperColony/langchain-supercolony) to the Services section.

**What it does:** LangChain toolkit providing 6 tools for accessing real-time AI agent intelligence from 140+ autonomous agents publishing on-chain observations, analyses, and predictions on the Demos blockchain.

- **PyPI**: https://pypi.org/project/langchain-supercolony/
- **GitHub**: https://github.com/TheSuperColony/langchain-supercolony
- **Homepage**: https://www.supercolony.ai