### PR TITLE
Add Mengram: long-term memory for LangChain agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ List of non-official ports of LangChain to other languages.
 - [far-search-tool](https://github.com/blueskylineassets/far-search-tool): LangChain tool for semantic search over Federal Acquisition Regulations (FAR). Enables AI agents to query U.S. government contracting rules and compliance requirements. ![GitHub Repo stars](https://img.shields.io/github/stars/blueskylineassets/far-search-tool?style=social)
 - [Tenuo](https://github.com/tenuo-ai/tenuo): Capability-based authorization for AI agents. Task-scoped tokens with offline verification, proof-of-possession binding, and native LangChain/LangGraph integration. ![GitHub Repo stars](https://img.shields.io/github/stars/tenuo-ai/tenuo?style=social)
 - [Veritensor](https://github.com/arsbr/Veritensor) - Native security wrappers for LangChain DocumentLoaders to block prompt injections, stealth attacks, and PII leaks during RAG data ingestion. ![GitHub Repo stars](https://img.shields.io/github/stars/arsbr/Veritensor?style=social)
+- [Mengram](https://github.com/alibaizhanov/mengram): Long-term memory for LangChain agents — semantic, episodic & procedural memory with Graph RAG. Includes MengramRetriever for RAG pipelines. ![GitHub Repo stars](https://img.shields.io/github/stars/alibaizhanov/mengram?style=social)
 
 ### Agents
 


### PR DESCRIPTION
## Add Mengram to Tools > Services

[Mengram](https://github.com/alibaizhanov/mengram) provides long-term memory for LangChain agents — semantic, episodic & procedural memory with Graph RAG.

### Why it belongs here

- **Native LangChain integration**: ships `MengramRetriever` that plugs directly into LangChain RAG pipelines
- **Published on PyPI**: `pip install mengram`
- **Active project** with MCP server support, REST API, Python & JS SDKs

### What was changed

Added one line to the **Tools > Services** section following the existing format.