### PR TITLE
Add Ziran security testing framework

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ List of non-official ports of LangChain to other languages.
 - [Tenuo](https://github.com/tenuo-ai/tenuo): Capability-based authorization for AI agents. Task-scoped tokens with offline verification, proof-of-possession binding, and native LangChain/LangGraph integration. ![GitHub Repo stars](https://img.shields.io/github/stars/tenuo-ai/tenuo?style=social)
 - [Veritensor](https://github.com/arsbr/Veritensor) - Native security wrappers for LangChain DocumentLoaders to block prompt injections, stealth attacks, and PII leaks during RAG data ingestion. ![GitHub Repo stars](https://img.shields.io/github/stars/arsbr/Veritensor?style=social)
 - [Mengram](https://github.com/alibaizhanov/mengram): Long-term memory for LangChain agents — semantic, episodic & procedural memory with Graph RAG. Includes MengramRetriever for RAG pipelines. ![GitHub Repo stars](https://img.shields.io/github/stars/alibaizhanov/mengram?style=social)
+- [Ziran](https://github.com/taoq-ai/ziran): Open-source security testing framework for AI agents. Discovers dangerous tool chain compositions via graph analysis, detects execution-level side effects, and runs multi-phase trust exploitation campaigns. ![GitHub Repo stars](https://img.shields.io/github/stars/taoq-ai/ziran?style=social)
 
 ### Agents
 


### PR DESCRIPTION
## What is Ziran?

[Ziran](https://github.com/taoq-ai/ziran) is an open-source security testing framework purpose-built for AI agents. It supports LangChain as a first-class adapter and helps developers discover vulnerabilities in agentic workflows before they reach production.

### Key capabilities

- **Graph-based tool chain analysis** — maps tool compositions and identifies dangerous execution paths
- **Side-effect detection** — catches execution-level side effects that static analysis misses
- **Trust exploitation campaigns** — runs multi-phase campaigns to test agent trust boundaries

### Why add it here?

Security tooling for LangChain agents is an underserved area. Ziran fills this gap by providing a dedicated testing framework that integrates natively with LangChain. More context on the motivation and approach: https://leoneperdigao.medium.com/your-ai-agent-has-a-backdoor-heres-how-i-found-it-1ad50124cacf

The entry was added at the bottom of the Services section, following the contribution guidelines.