### PR TITLE
Add Grantex — agent authorization integration for LangChain

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,8 @@ List of non-official ports of LangChain to other languages.
 - [Tenuo](https://github.com/tenuo-ai/tenuo): Capability-based authorization for AI agents. Task-scoped tokens with offline verification, proof-of-possession binding, and native LangChain/LangGraph integration. ![GitHub Repo stars](https://img.shields.io/github/stars/tenuo-ai/tenuo?style=social)
 - [Veritensor](https://github.com/arsbr/Veritensor) - Native security wrappers for LangChain DocumentLoaders to block prompt injections, stealth attacks, and PII leaks during RAG data ingestion. ![GitHub Repo stars](https://img.shields.io/github/stars/arsbr/Veritensor?style=social)
 
+- [Grantex](https://github.com/mishrasanjeev/grantex): Open delegated authorization for LangChain agents — scoped, time-limited, revocable JWT permissions with delegation chains and budget controls. ![GitHub Repo stars](https://img.shields.io/github/stars/mishrasanjeev/grantex?style=social)
+
 ### Agents
 
 - [Private GPT](https://github.com/imartinez/privateGPT): Interact privately with your documents using the power of GPT, 100% privately, no data leaks ![GitHub Repo stars](https://img.shields.io/github/stars/imartinez/privateGPT?style=social)


### PR DESCRIPTION
Adds Grantex to the Services section.

Grantex is an open delegated authorization protocol for AI agents with a native LangChain integration (`@grantex/langchain`). It wraps LangChain tool calls with scoped, time-limited, revocable JWT permissions, delegation chains, and budget controls.

- GitHub: https://github.com/mishrasanjeev/grantex
- LangChain integration: https://docs.grantex.dev/integrations/langchain