### PR TITLE
Add WritBase to Tools > Agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ List of non-official ports of LangChain to other languages.
 - [Autonomous HR Chatbot](https://github.com/stepanogil/autonomous-hr-chatbot): An autonomous agent that can answer HR related queries autonomously using the tools it has on hand ![GitHub Repo stars](https://img.shields.io/github/stars/stepanogil/autonomous-hr-chatbot?style=social)
 - [BlockAGI](https://github.com/blockpipe/blockagi): BlockAGI conducts iterative, domain-specific research, and outputs detailed narrative reports to showcase its findings ![GitHub Repo stars](https://img.shields.io/github/stars/blockpipe/blockagi?style=social)
 - [waggledance.ai](https://github.com/agi-merge/waggle-dance): An opinionated, concurrent system of AI Agents. It implements Plan-Validate-Solve with data and tools for general goal-solving. ![GitHub Repo stars](https://img.shields.io/github/stars/agi-merge/waggle-dance?style=social)
+- [WritBase](https://github.com/Writbase/writbase): MCP-native task management for AI agent fleets ![GitHub Repo stars](https://img.shields.io/github/stars/Writbase/writbase?style=social)
 
 
 ### Templates


### PR DESCRIPTION
## Summary
- Adds [WritBase](https://github.com/Writbase/writbase) to the Tools > Agents section
- WritBase is an MCP-native task management control plane for AI agent fleets with multi-agent permissions and full provenance

## Entry
Follows existing format with stars badge.