### PR TITLE
Add widemem-ai — open-source AI memory layer

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ List of non-official ports of LangChain to other languages.
 - [Mengram](https://github.com/alibaizhanov/mengram): Long-term memory for LangChain agents — semantic, episodic & procedural memory with Graph RAG. Includes MengramRetriever for RAG pipelines. ![GitHub Repo stars](https://img.shields.io/github/stars/alibaizhanov/mengram?style=social)
 - [Ziran](https://github.com/taoq-ai/ziran): Open-source security testing framework for AI agents. Discovers dangerous tool chain compositions via graph analysis, detects execution-level side effects, and runs multi-phase trust exploitation campaigns. ![GitHub Repo stars](https://img.shields.io/github/stars/taoq-ai/ziran?style=social)
 
+- [widemem-ai](https://github.com/remete618/widemem-ai): Next-gen AI memory layer with importance scoring, temporal decay, hierarchical memory, and YMYL prioritization. ![GitHub Repo stars](https://img.shields.io/github/stars/remete618/widemem-ai?style=social)
 ### Agents
 
 - [Private GPT](https://github.com/imartinez/privateGPT): Interact privately with your documents using the power of GPT, 100% privately, no data leaks ![GitHub Repo stars](https://img.shields.io/github/stars/imartinez/privateGPT?style=social)


### PR DESCRIPTION
Adding [widemem-ai](https://github.com/remete618/widemem-ai) — open-source AI memory layer with importance scoring, temporal decay, hierarchical memory, and YMYL prioritization.

- Website: https://widemem.ai
- License: MIT