### PR TITLE
Add Nex.ai — organizational context layer for LangChain agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ List of non-official ports of LangChain to other languages.
 - [Veritensor](https://github.com/arsbr/Veritensor) - Native security wrappers for LangChain DocumentLoaders to block prompt injections, stealth attacks, and PII leaks during RAG data ingestion. ![GitHub Repo stars](https://img.shields.io/github/stars/arsbr/Veritensor?style=social)
 - [Mengram](https://github.com/alibaizhanov/mengram): Long-term memory for LangChain agents — semantic, episodic & procedural memory with Graph RAG. Includes MengramRetriever for RAG pipelines. ![GitHub Repo stars](https://img.shields.io/github/stars/alibaizhanov/mengram?style=social)
 - [Ziran](https://github.com/taoq-ai/ziran): Open-source security testing framework for AI agents. Discovers dangerous tool chain compositions via graph analysis, detects execution-level side effects, and runs multi-phase trust exploitation campaigns. ![GitHub Repo stars](https://img.shields.io/github/stars/taoq-ai/ziran?style=social)
+- [Nex.ai](https://github.com/nex-crm/nex-as-a-skill): Organizational context & memory layer for AI agents. Connects LangChain agents to live CRM, email, Slack, and data warehouse data via REST API + SSE streaming. Works as a LangChain tool for real-time organizational context retrieval. ![GitHub Repo stars](https://img.shields.io/github/stars/nex-crm/nex-as-a-skill?style=social)
 
 ### Agents
 


### PR DESCRIPTION
## What is Nex.ai?

[nex-crm/nex-as-a-skill](https://github.com/nex-crm/nex-as-a-skill) is an organizational context & memory layer for AI agents. It connects LangChain agents to live organizational data — CRM (HubSpot, Salesforce), email (Gmail, Outlook), Slack, and data warehouses — via REST API + SSE streaming.

## Why it belongs in Services

This directly solves the most common LangChain production failure: agents that can't access real-time organizational data and end up hallucinating answers about customers, deals, or internal processes.

**LangChain integration pattern:**
```python
from langchain.tools import Tool
import requests

def get_org_context(query: str) -> str:
    response = requests.post(
        "https://app.nex.ai/api/developers/context",
        headers={"Authorization": f"Bearer {NEX_API_KEY}"},
        json={"query": query}
    )
    return response.json().get("context", "")

nex_tool = Tool(
    name="OrganizationalContext",
    func=get_org_context,
    description="Get real-time organizational context: customers, deals, relationships"
)
```

Also available as a LangChain-compatible MCP server, Claude Code plugin, and CLI.

## Entry added

Under `### Services`:
```
- [Nex.ai](https://github.com/nex-crm/nex-as-a-skill): Organizational context & memory layer for AI agents. Connects LangChain agents to live CRM, email, Slack, and data warehouse data via REST API + SSE streaming.
```