### PR TITLE
Add Network-AI to Agents section

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ List of non-official ports of LangChain to other languages.
 - [Autonomous HR Chatbot](https://github.com/stepanogil/autonomous-hr-chatbot): An autonomous agent that can answer HR related queries autonomously using the tools it has on hand ![GitHub Repo stars](https://img.shields.io/github/stars/stepanogil/autonomous-hr-chatbot?style=social)
 - [BlockAGI](https://github.com/blockpipe/blockagi): BlockAGI conducts iterative, domain-specific research, and outputs detailed narrative reports to showcase its findings ![GitHub Repo stars](https://img.shields.io/github/stars/blockpipe/blockagi?style=social)
 - [waggledance.ai](https://github.com/agi-merge/waggle-dance): An opinionated, concurrent system of AI Agents. It implements Plan-Validate-Solve with data and tools for general goal-solving. ![GitHub Repo stars](https://img.shields.io/github/stars/agi-merge/waggle-dance?style=social)
+- [Network-AI](https://github.com/Jovancoding/Network-AI): Multi-agent orchestration layer with native LangChain adapter (including streaming). Adds race-condition-safe shared blackboard, per-agent token budgets, and permission gating on top of existing LangChain runnables. Supports 15 frameworks in the same swarm. ![GitHub Repo stars](https://img.shields.io/github/stars/Jovancoding/Network-AI?style=social)
 
 
 ### Templates


### PR DESCRIPTION
## Network-AI

[Network-AI](https://github.com/Jovancoding/Network-AI) is a multi-agent orchestration layer with a native LangChain adapter (including streaming support).

**LangChain integration:**
- \LangChainAdapter\ — register any Runnable, execute via the orchestrator
- \LangChainStreamingAdapter\ — calls \.stream()\ on the Runnable with chunk-by-chunk output
- Mix LangChain agents with AutoGen, CrewAI, MCP, or any other supported framework in the same swarm

**Core features:**
- Atomic shared blackboard (\propose → validate → commit\ with file-system mutex)
- 15 framework adapters total
- AuthGuardian permission gating with scoped tokens
- FederatedBudget — per-agent token ceilings
- HMAC-signed audit trail
- 1,449 tests across 18 suites

**Links:**
- npm: https://www.npmjs.com/package/network-ai
- GitHub: https://github.com/Jovancoding/Network-AI

Added to the Agents section, following the existing format with GitHub star badge.