### PR TITLE
Add langchain-browseaidev: LangChain tools for evidence-backed web research

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ List of non-official ports of LangChain to other languages.
 - [Veritensor](https://github.com/arsbr/Veritensor) - Native security wrappers for LangChain DocumentLoaders to block prompt injections, stealth attacks, and PII leaks during RAG data ingestion. ![GitHub Repo stars](https://img.shields.io/github/stars/arsbr/Veritensor?style=social)
 - [Mengram](https://github.com/alibaizhanov/mengram): Long-term memory for LangChain agents — semantic, episodic & procedural memory with Graph RAG. Includes MengramRetriever for RAG pipelines. ![GitHub Repo stars](https://img.shields.io/github/stars/alibaizhanov/mengram?style=social)
 - [Ziran](https://github.com/taoq-ai/ziran): Open-source security testing framework for AI agents. Discovers dangerous tool chain compositions via graph analysis, detects execution-level side effects, and runs multi-phase trust exploitation campaigns. ![GitHub Repo stars](https://img.shields.io/github/stars/taoq-ai/ziran?style=social)
+- [langchain-browseaidev](https://github.com/BrowseAI-HQ/BrowseAI-Dev/tree/main/packages/langchain-browseaidev): LangChain tools for evidence-backed web research with citations and confidence scores. ![GitHub Repo stars](https://img.shields.io/github/stars/BrowseAI-HQ/BrowseAI-Dev?style=social)
 
 ### Agents
 


### PR DESCRIPTION
## What is langchain-browseaidev?

[langchain-browseaidev](https://github.com/BrowseAI-HQ/BrowseAI-Dev/tree/main/packages/langchain-browseaidev) provides LangChain tools for evidence-backed web research with citations and confidence scores.

It wraps [BrowseAI Dev](https://github.com/BrowseAI-HQ/BrowseAI-Dev) — open-source research infrastructure for AI agents — as native LangChain tools:

- **BrowseAISearchTool** — Web search with source citations
- **BrowseAIAnswerTool** — Research questions with evidence-backed answers and confidence scores
- **BrowseAIExtractTool** — Extract structured data from URLs with claim verification
- **BrowseAICompareTool** — Compare topics with verified evidence from multiple sources

### Key features
- Evidence-backed citations with confidence scores (not LLM self-assessed)
- Hybrid BM25 + NLI semantic verification pipeline
- Cross-source consensus and contradiction detection
- Domain authority scoring (10,000+ domains)
- Available as LangChain tools, MCP server, REST API, and Python SDK

### Links
- **GitHub:** https://github.com/BrowseAI-HQ/BrowseAI-Dev
- **npm:** https://www.npmjs.com/package/browseai-dev
- **PyPI:** https://pypi.org/project/browseaidev/
- **License:** MIT

### Where was it added?
Tools > Services section, at the bottom of the list.