### PR TITLE
Add DexPaprika MCP Server to Services

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ List of non-official ports of LangChain to other languages.
 - [Veritensor](https://github.com/arsbr/Veritensor) - Native security wrappers for LangChain DocumentLoaders to block prompt injections, stealth attacks, and PII leaks during RAG data ingestion. ![GitHub Repo stars](https://img.shields.io/github/stars/arsbr/Veritensor?style=social)
 - [Mengram](https://github.com/alibaizhanov/mengram): Long-term memory for LangChain agents — semantic, episodic & procedural memory with Graph RAG. Includes MengramRetriever for RAG pipelines. ![GitHub Repo stars](https://img.shields.io/github/stars/alibaizhanov/mengram?style=social)
 - [Ziran](https://github.com/taoq-ai/ziran): Open-source security testing framework for AI agents. Discovers dangerous tool chain compositions via graph analysis, detects execution-level side effects, and runs multi-phase trust exploitation campaigns. ![GitHub Repo stars](https://img.shields.io/github/stars/taoq-ai/ziran?style=social)
+- [DexPaprika MCP Server](https://github.com/coinpaprika/dexpaprika-mcp): MCP server providing free real-time DEX data across all chains for LangChain agents — pools, tokens, trades, OHLCV with no API key needed ![GitHub Repo stars](https://img.shields.io/github/stars/coinpaprika/dexpaprika-mcp?style=social)
 
 ### Agents
 


### PR DESCRIPTION
Adds the DexPaprika MCP Server to the Tools > Services section.

Provides free real-time DEX data across all chains for LangChain agents — pools, tokens, trades, OHLCV. No API key needed, no rate limits.

- GitHub: https://github.com/coinpaprika/dexpaprika-mcp
- Works with LangChain via `langchain-mcp-adapters`