### PR TITLE
Add Kybernis Audit to Services

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ List of non-official ports of LangChain to other languages.
 - [Flock](https://github.com/Onelevenvy/flock): Flock is a workflow-based low-code platform for rapidly building chatbots, RAG, and coordinating multi-agent teams![GitHub Repo stars](https://img.shields.io/github/stars/Onelevenvy/flock?style=social)
   
 ### Services
+- [Kybernis Audit](https://github.com/Kybernis/kybernis-audit): The execution safety layer for AI agents. Prevents semantic double-spends and infinite retry loops by hard-blocking duplicate API calls. ![GitHub Repo stars](https://img.shields.io/github/stars/Kybernis/kybernis-audit?style=social)
 
 - [GPTCache](https://github.com/zilliztech/GPTCache): A Library for Creating Semantic Cache for LLM Queries ![GitHub Repo stars](https://img.shields.io/github/stars/zilliztech/GPTCache?style=social)
 - [Gorilla](https://github.com/ShishirPatil/gorilla): An API store for LLMs ![GitHub Repo stars](https://img.shields.io/github/stars/ShishirPatil/gorilla?style=social)


### PR DESCRIPTION
Adding Kybernis Audit to the Services list. It provides execution safety and prevents semantic double-spends for agents built with LangChain.