### PR TITLE
Add voidly-agents to Services section

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ List of non-official ports of LangChain to other languages.
 - [Veritensor](https://github.com/arsbr/Veritensor) - Native security wrappers for LangChain DocumentLoaders to block prompt injections, stealth attacks, and PII leaks during RAG data ingestion. ![GitHub Repo stars](https://img.shields.io/github/stars/arsbr/Veritensor?style=social)
 - [Mengram](https://github.com/alibaizhanov/mengram): Long-term memory for LangChain agents — semantic, episodic & procedural memory with Graph RAG. Includes MengramRetriever for RAG pipelines. ![GitHub Repo stars](https://img.shields.io/github/stars/alibaizhanov/mengram?style=social)
 - [Ziran](https://github.com/taoq-ai/ziran): Open-source security testing framework for AI agents. Discovers dangerous tool chain compositions via graph analysis, detects execution-level side effects, and runs multi-phase trust exploitation campaigns. ![GitHub Repo stars](https://img.shields.io/github/stars/taoq-ai/ziran?style=social)
+- [voidly-agents](https://github.com/voidly-ai/python-sdk): Python SDK for E2E encrypted agent-to-agent communication with LangChain integration (VoidlyToolkit — 9 tools for encrypted messaging, channels, task delegation, attestations, discovery, and memory). ![GitHub Repo stars](https://img.shields.io/github/stars/voidly-ai/python-sdk?style=social)
 
 ### Agents
 


### PR DESCRIPTION
## Summary

- Adds [voidly-agents](https://github.com/voidly-ai/python-sdk) to the **Services** section
- Python SDK for E2E encrypted agent-to-agent communication
- Includes LangChain integration via `VoidlyToolkit` (9 ready-made tools for encrypted messaging, channels, task delegation, attestations, discovery, and memory)
- Also includes CrewAI integration (7 tools)
- Available on [PyPI](https://pypi.org/project/voidly-agents/) — install with `pip install voidly-agents[langchain]`

## Details

voidly-agents provides secure agent-to-agent communication infrastructure with:
- End-to-end encryption (Double Ratchet, X3DH, post-quantum ML-KEM-768)
- Native LangChain `BaseTool` implementations via `VoidlyToolkit`
- Encrypted channels, task delegation, attestations, discovery, and persistent memory
- CrewAI integration with 7 tools

🤖 Generated with [Claude Code](https://claude.com/claude-code)