### PR TITLE
Add Cerberus — runtime security for LangChain agents (prompt injection + exfiltration detection)

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ List of non-official ports of LangChain to other languages.
 - [Veritensor](https://github.com/arsbr/Veritensor) - Native security wrappers for LangChain DocumentLoaders to block prompt injections, stealth attacks, and PII leaks during RAG data ingestion. ![GitHub Repo stars](https://img.shields.io/github/stars/arsbr/Veritensor?style=social)
 - [Mengram](https://github.com/alibaizhanov/mengram): Long-term memory for LangChain agents — semantic, episodic & procedural memory with Graph RAG. Includes MengramRetriever for RAG pipelines. ![GitHub Repo stars](https://img.shields.io/github/stars/alibaizhanov/mengram?style=social)
 - [Ziran](https://github.com/taoq-ai/ziran): Open-source security testing framework for AI agents. Discovers dangerous tool chain compositions via graph analysis, detects execution-level side effects, and runs multi-phase trust exploitation campaigns. ![GitHub Repo stars](https://img.shields.io/github/stars/taoq-ai/ziran?style=social)
+- [Cerberus](https://github.com/Odingard/cerberus): Runtime security for LangChain agents. Detects prompt injection + data exfiltration via Lethal Trifecta correlation. `wrap_chain()` / `wrap_agent()` integration, callback handler, 52μs overhead. TypeScript + Python. ![GitHub Repo stars](https://img.shields.io/github/stars/Odingard/cerberus?style=social)
 
 ### Agents
 


### PR DESCRIPTION
Adding Cerberus to the tools section alongside other security tools (Agentic Radar, Veritensor, Ziran).

Cerberus provides runtime security for LangChain agents via `wrap_chain()`, `wrap_agent()`, and a `CerberusCallbackHandler`. Detects the Lethal Trifecta — when privileged data access, prompt injection, and an outbound exfiltration path converge in a single execution turn.

```python
pip install cerberus-ai[langchain]

from cerberus_ai.integrations.langchain import wrap_chain
secured = wrap_chain(my_chain, config=config)
```

- 52μs overhead, 0.0% false positive rate
- N=525 validated across OpenAI, Anthropic, Google
- TypeScript (@cerberus-ai/core) + Python (cerberus-ai)
- Apache 2.0: https://github.com/Odingard/cerberus