### PR TITLE
Add Aegis to Tools > Services

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ List of non-official ports of LangChain to other languages.
 - [Veritensor](https://github.com/arsbr/Veritensor) - Native security wrappers for LangChain DocumentLoaders to block prompt injections, stealth attacks, and PII leaks during RAG data ingestion. ![GitHub Repo stars](https://img.shields.io/github/stars/arsbr/Veritensor?style=social)
 - [Mengram](https://github.com/alibaizhanov/mengram): Long-term memory for LangChain agents — semantic, episodic & procedural memory with Graph RAG. Includes MengramRetriever for RAG pipelines. ![GitHub Repo stars](https://img.shields.io/github/stars/alibaizhanov/mengram?style=social)
 - [Ziran](https://github.com/taoq-ai/ziran): Open-source security testing framework for AI agents. Discovers dangerous tool chain compositions via graph analysis, detects execution-level side effects, and runs multi-phase trust exploitation campaigns. ![GitHub Repo stars](https://img.shields.io/github/stars/taoq-ai/ziran?style=social)
+- [Aegis](https://github.com/Acacian/aegis): Policy-based governance middleware for AI agents. YAML-driven risk evaluation (<1ms), approval gates, and audit logging. Works with LangChain and 6 other frameworks. [Playground](https://acacian.github.io/aegis/playground/) ![GitHub Repo stars](https://img.shields.io/github/stars/Acacian/aegis?style=social)
 
 ### Agents
 


### PR DESCRIPTION
Hi @sbusso,

## Add Aegis to Tools > Services

[Aegis](https://github.com/Acacian/aegis) is a policy-based governance middleware that ships a native LangChain callback handler. It intercepts tool calls and evaluates them against YAML policy rules in under 1ms — returning `auto` (allow), `approve` (human review), or `block` (deny).

### LangChain integration

```python
from langchain.agents import AgentExecutor
from aegis import AegisEngine
from aegis.contrib.langchain import AegisCallbackHandler

engine = AegisEngine.from_file("policy.yaml")

# Drop-in — zero wrapper code needed
agent = AgentExecutor(
    agent=my_agent,
    tools=my_tools,
    callbacks=[AegisCallbackHandler(engine)],
)
agent.invoke({"input": "delete all records"})
# → AegisCallbackHandler intercepts the tool call,
#   evaluates risk via policy, and blocks if needed
```

### Why it belongs here

LangChain makes it easy to build agents, but **governing what those agents can actually do** is still manual. Aegis fills this gap with declarative YAML policies — no code changes to the agent itself. The callback handler hooks into LangChain's existing callback system, so it works with any `AgentExecutor`, chain, or LangGraph workflow.

- **Native LangChain integration**: `AegisCallbackHandler` — plugs into `callbacks=[]` with one line
- **Published on PyPI**: `pip install agent-aegis`
- **Sub-millisecond evaluation**: policy decisions in <1ms, no added latency
- **Interactive playground**: [Try policies in-browser](https://acacian.github.io/aegis/playground/) — no install needed

### What was changed

Added one line to the **Tools > Services** section at the bottom, following the contribution guidelines.