### PR TITLE
Add Spraay Agent Wallet LangChain tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ List of non-official ports of LangChain to other languages.
 - [Veritensor](https://github.com/arsbr/Veritensor) - Native security wrappers for LangChain DocumentLoaders to block prompt injections, stealth attacks, and PII leaks during RAG data ingestion. ![GitHub Repo stars](https://img.shields.io/github/stars/arsbr/Veritensor?style=social)
 - [Mengram](https://github.com/alibaizhanov/mengram): Long-term memory for LangChain agents — semantic, episodic & procedural memory with Graph RAG. Includes MengramRetriever for RAG pipelines. ![GitHub Repo stars](https://img.shields.io/github/stars/alibaizhanov/mengram?style=social)
 - [Ziran](https://github.com/taoq-ai/ziran): Open-source security testing framework for AI agents. Discovers dangerous tool chain compositions via graph analysis, detects execution-level side effects, and runs multi-phase trust exploitation campaigns. ![GitHub Repo stars](https://img.shields.io/github/stars/taoq-ai/ziran?style=social)
+- [Spraay Agent Wallet](https://github.com/plagtech/langchain-spraay-wallet): 💧 Smart contract wallet provisioning for AI agents on Base. Session keys, spending limits, and time-bound permissions via x402 USDC micropayments.
 
 ### Agents
 


### PR DESCRIPTION
💧 Adds Spraay Agent Wallet to the Tools section.

5 LangChain StructuredTools for provisioning smart wallets, managing session keys, and predicting wallet addresses on Base via x402 USDC micropayments.

Repo: https://github.com/plagtech/langchain-spraay-wallet
Gateway: https://gateway.spraay.app