### PR TITLE
Add LongTracer — RAG hallucination detection and tracing for LangChain

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ List of non-official ports of LangChain to other languages.
 - [LangWatch](https://github.com/langwatch/langwatch): An Open Source tool for observing, evaluating and optimising your llm apps and prompts, which supports LangChain out of the box! ![GitHub Repo stars](https://img.shields.io/github/stars/langwatch/langwatch?style=social)
 - [Agentic Radar](https://github.com/splx-ai/agentic-radar) - Open-source CLI security scanner for agentic workflows. Scans your workflow’s source code, detects vulnerabilities, and generates an interactive visualization along with a detailed security report. ![GitHub Repo stars](https://img.shields.io/github/stars/splx-ai/agentic-radar?style=social)
 - [UQLM](https://github.com/cvs-health/uqlm): UQLM: Uncertainty Quantification for Language Models, is a Python library for LLM hallucination detection using state-of-the-art uncertainty quantification techniques ![GitHub Repo stars](https://img.shields.io/github/stars/cvs-health/uqlm?style=social)
+- [LongTracer](https://github.com/ENDEVSOLS/LongTracer): RAG hallucination detection and multi-project tracing SDK. Verifies every claim against source documents using hybrid STS + NLI, integrates with LangChain in 3 lines. ![GitHub Repo stars](https://img.shields.io/github/stars/ENDEVSOLS/LongTracer?style=social)
 
 ### Agents
 


### PR DESCRIPTION
LongTracer is an open-source Python SDK for detecting hallucinations in RAG pipelines.

- Verifies LLM claims against source documents using hybrid STS + NLI
- Works with LangChain, LlamaIndex, Haystack, LangGraph in 3 lines
- Pluggable backends: SQLite, MongoDB, Redis, PostgreSQL
- MIT licensed, published on PyPI: pip install longtracer
- GitHub: https://github.com/ENDEVSOLS/LongTracer
