### PR TITLE
Add Harness Evolver to Tools > Services

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ List of non-official ports of LangChain to other languages.
 - [LangWatch](https://github.com/langwatch/langwatch): An Open Source tool for observing, evaluating and optimising your llm apps and prompts, which supports LangChain out of the box! ![GitHub Repo stars](https://img.shields.io/github/stars/langwatch/langwatch?style=social)
 - [Agentic Radar](https://github.com/splx-ai/agentic-radar) - Open-source CLI security scanner for agentic workflows. Scans your workflow’s source code, detects vulnerabilities, and generates an interactive visualization along with a detailed security report. ![GitHub Repo stars](https://img.shields.io/github/stars/splx-ai/agentic-radar?style=social)
 - [UQLM](https://github.com/cvs-health/uqlm): UQLM: Uncertainty Quantification for Language Models, is a Python library for LLM hallucination detection using state-of-the-art uncertainty quantification techniques ![GitHub Repo stars](https://img.shields.io/github/stars/cvs-health/uqlm?style=social)
+- [Harness Evolver](https://github.com/raphaelchristi/harness-evolver): Autonomous agent optimization plugin that uses LangSmith Datasets, Experiments, and LLM-as-judge evaluation to evolve LangChain/LangGraph agents in isolated git worktrees. ![GitHub Repo stars](https://img.shields.io/github/stars/raphaelchristi/harness-evolver?style=social)
 
 ### Agents
 


### PR DESCRIPTION
## Summary
Adds [Harness Evolver](https://github.com/raphaelchristi/harness-evolver) to the Tools > Services section.

## What it is
Autonomous agent optimization plugin that uses LangSmith Datasets, Experiments, and LLM-as-judge evaluation to evolve LangChain/LangGraph agents. Multi-agent proposers modify code in isolated git worktrees and compete via LangSmith experiments.

- npm: `npx harness-evolver@latest`