### PR TITLE
Add LongTrainer to the list

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,7 @@ List of non-official ports of LangChain to other languages.
 
 ### Other / Chatbots
 
+- [LongTrainer](https://github.com/ENDEVSOLS/Long-Trainer): A production-ready RAG framework based on LangChain for building intelligent, multi-tenant chatbots with tool calling, memory, and streaming capabilities. ![GitHub Repo stars](https://img.shields.io/github/stars/ENDEVSOLS/Long-Trainer?style=social)
 - [DB GPT](https://github.com/csunny/DB-GPT): Interact your data and environment using the local GPT, no data leaks, 100% privately, 100% security ![GitHub Repo stars](https://img.shields.io/github/stars/csunny/DB-GPT?style=social)
 - [AudioGPT](https://github.com/AIGC-Audio/AudioGPT): Understanding and Generating Speech, Music, Sound, and Talking Head ![GitHub Repo stars](https://img.shields.io/github/stars/AIGC-Audio/AudioGPT?style=social)
 - [Paper QA](https://github.com/whitead/paper-qa): LLM Chain for answering questions from documents with citations ![GitHub Repo stars](https://img.shields.io/github/stars/whitead/paper-qa?style=social)


### PR DESCRIPTION
Hi there! 👋

I would like to propose adding **[LongTrainer](https://github.com/ENDEVSOLS/Long-Trainer)** to this awesome list. 

### What is LongTrainer?
LongTrainer is a production-ready framework built on top of LangChain. It allows developers to turn their documents into intelligent, multi-tenant chatbots with just a few lines of code. 

### Why is it a good fit here?
It abstracts away the complexities of manually wiring together chains, memory, tools, and retrievers by offering batteries-included features for production:
- **Multi-bot architecture:** Built-in multi-tenant isolation for managing separate bots effortlessly.
- **Persistent Memory:** Ready-to-use MongoDB-backed, encrypted chat history.
- **Agentic Capabilities:** Supports both standard RAG pipelines and dynamic LangGraph agent tool-calling (web search, custom functions).
- **Extensive Document & Vision Support:** Natively parses PDFs, databases, URLs, and multi-modal images without friction.
- **Streaming:** First-class support for sync and async streaming out of the box.

I believe this will be an extremely valuable, time-saving resource for developers in this community looking to spin up robust GenAI/RAG applications in production quickly.

Thank you for your time and for maintaining this awesome list! Let me know if you need me to adjust the formatting to better fit the repository guidelines. 
