### PR TITLE
Add agent-aegis to Services

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ List of non-official ports of LangChain to other languages.
 - [LangWatch](https://github.com/langwatch/langwatch): An Open Source tool for observing, evaluating and optimising your llm apps and prompts, which supports LangChain out of the box! ![GitHub Repo stars](https://img.shields.io/github/stars/langwatch/langwatch?style=social)
 - [Agentic Radar](https://github.com/splx-ai/agentic-radar) - Open-source CLI security scanner for agentic workflows. Scans your workflow’s source code, detects vulnerabilities, and generates an interactive visualization along with a detailed security report. ![GitHub Repo stars](https://img.shields.io/github/stars/splx-ai/agentic-radar?style=social)
 - [UQLM](https://github.com/cvs-health/uqlm): UQLM: Uncertainty Quantification for Language Models, is a Python library for LLM hallucination detection using state-of-the-art uncertainty quantification techniques ![GitHub Repo stars](https://img.shields.io/github/stars/cvs-health/uqlm?style=social)
+- [agent-aegis](https://github.com/Acacian/aegis): Runtime governance for AI agents. Auto-instruments LangChain with guardrails, selection audit, and Merkle audit trail. ![GitHub Repo stars](https://img.shields.io/github/stars/Acacian/aegis?style=social)
 
 ### Agents
 


### PR DESCRIPTION
[agent-aegis](https://github.com/Acacian/aegis) is a runtime governance library for AI agents. It auto-instruments LangChain with guardrails, selection audit, and Merkle audit trail.

It fits in **Services** alongside LangFair, LangWatch, and Agentic Radar as a tool that adds observability and safety to LangChain workflows.