### PR TITLE
Add omega-memory - persistent memory for AI agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -304,6 +304,7 @@ List of non-official ports of LangChain to other languages.
 - [TensorZero](https://github.com/tensorzero/tensorzero): An open-source framework for building production-grade LLM applications. It unifies an LLM gateway, observability, optimization, evaluations, and experimentation. ![GitHub Repo stars](https://img.shields.io/github/stars/tensorzero/tensorzero?style=social)
 - [Bifrost](https://github.com/maximhq/bifrost): Bifrost is the fastest LLM gateway, with just 11μs overhead at 5,000 RPS, making it 50x faster than LiteLLM. ![GitHub Repo stars](https://img.shields.io/github/stars/maximhq/bifrost?style=social)
 - [Mastra AI](https://github.com/mastra-ai/mastra): a framework for building AI-powered applications and agents with a modern TypeScript stack.
+- [omega-memory](https://github.com/omega-memory/omega-memory): Persistent memory system for AI agents with semantic search, auto-capture, and cross-session learning via MCP. ![GitHub Repo stars](https://img.shields.io/github/stars/omega-memory/omega-memory?style=social)
 
 ## Complement to this list
 


### PR DESCRIPTION
## What

Adds [omega-memory](https://github.com/omega-memory/omega-memory) to the **Other LLM Frameworks** section.

## About omega-memory

Persistent memory system for AI agents with semantic search, auto-capture, and cross-session learning via MCP. Framework-agnostic memory layer that works with any AI coding agent.

- **GitHub**: https://github.com/omega-memory/omega-memory
- **PyPI**: https://pypi.org/project/omega-memory/
- **Open source**: Apache-2.0 license
- **Actively maintained**: Regular releases, 80+ GitHub stars

Placed at the bottom of the "Other LLM Frameworks" section per contribution guidelines.