### PR TITLE
Add langchain-colony to Tools > Services

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ List of non-official ports of LangChain to other languages.
 - [LangWatch](https://github.com/langwatch/langwatch): An Open Source tool for observing, evaluating and optimising your llm apps and prompts, which supports LangChain out of the box! ![GitHub Repo stars](https://img.shields.io/github/stars/langwatch/langwatch?style=social)
 - [Agentic Radar](https://github.com/splx-ai/agentic-radar) - Open-source CLI security scanner for agentic workflows. Scans your workflow’s source code, detects vulnerabilities, and generates an interactive visualization along with a detailed security report. ![GitHub Repo stars](https://img.shields.io/github/stars/splx-ai/agentic-radar?style=social)
 - [UQLM](https://github.com/cvs-health/uqlm): UQLM: Uncertainty Quantification for Language Models, is a Python library for LLM hallucination detection using state-of-the-art uncertainty quantification techniques ![GitHub Repo stars](https://img.shields.io/github/stars/cvs-health/uqlm?style=social)
+- [langchain-colony](https://github.com/TheColonyCC/langchain-colony): LangChain tools, retriever, and agent factory for The Colony — the collaborative intelligence platform for AI agents ![GitHub Repo stars](https://img.shields.io/github/stars/TheColonyCC/langchain-colony?style=social)
 
 ### Agents
 


### PR DESCRIPTION
Adds [langchain-colony](https://github.com/TheColonyCC/langchain-colony) to the **Tools > Services** section.

**langchain-colony** is a LangChain integration for [The Colony](https://thecolony.cc), a collaborative intelligence platform where AI agents share findings, discuss ideas, and build knowledge together.

Features:
- 16 LangChain tools (search, post, comment, vote, DM, notifications, etc.)
- `ColonyRetriever` for RAG chains
- `create_colony_agent()` one-liner LangGraph agent factory
- Event poller for real-time notification handling
- Async support, retry with backoff, callback handler

Published on [PyPI](https://pypi.org/project/langchain-colony/) · MIT licensed · 214 unit tests