### PR TITLE
Add BulkPublish to Services

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ List of non-official ports of LangChain to other languages.
 - [LangWatch](https://github.com/langwatch/langwatch): An Open Source tool for observing, evaluating and optimising your llm apps and prompts, which supports LangChain out of the box! ![GitHub Repo stars](https://img.shields.io/github/stars/langwatch/langwatch?style=social)
 - [Agentic Radar](https://github.com/splx-ai/agentic-radar) - Open-source CLI security scanner for agentic workflows. Scans your workflow’s source code, detects vulnerabilities, and generates an interactive visualization along with a detailed security report. ![GitHub Repo stars](https://img.shields.io/github/stars/splx-ai/agentic-radar?style=social)
 - [UQLM](https://github.com/cvs-health/uqlm): UQLM: Uncertainty Quantification for Language Models, is a Python library for LLM hallucination detection using state-of-the-art uncertainty quantification techniques ![GitHub Repo stars](https://img.shields.io/github/stars/cvs-health/uqlm?style=social)
+- [BulkPublish](https://github.com/azeemkafridi/bulkpublish-api): Social media publishing API with a ready-to-use LangChain tool, MCP server (29 tools), and Python/Node.js SDKs for AI agent workflows ![GitHub Repo stars](https://img.shields.io/github/stars/azeemkafridi/bulkpublish-api?style=social)
 
 ### Agents
 


### PR DESCRIPTION
## Summary

Adds [BulkPublish](https://www.bulkpublish.com) to the **Tools > Services** section.

BulkPublish is a social media publishing API with built-in LangChain support:

- **LangChain tool**: ready-to-use example at `examples/ai-agents/langchain_tool.py`
- **MCP server**: `@bulkpublish/mcp-server` with 29 tools for AI agent workflows
- **Python SDK**: `pip install bulkpublish`
- **Node.js SDK**: `npm install bulkpublish`
- **GitHub**: https://github.com/azeemkafridi/bulkpublish-api
- **API docs**: https://app.bulkpublish.com/docs

The LangChain tool allows AI agents to create, schedule, and manage social media posts across multiple platforms (Twitter/X, LinkedIn, Instagram, Facebook, etc.) through natural language.

Free to use ($0 forever, API access included).