### PR TITLE
Add langchain-quantoracle

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ List of non-official ports of LangChain to other languages.
 - [LangWatch](https://github.com/langwatch/langwatch): An Open Source tool for observing, evaluating and optimising your llm apps and prompts, which supports LangChain out of the box! ![GitHub Repo stars](https://img.shields.io/github/stars/langwatch/langwatch?style=social)
 - [Agentic Radar](https://github.com/splx-ai/agentic-radar) - Open-source CLI security scanner for agentic workflows. Scans your workflow’s source code, detects vulnerabilities, and generates an interactive visualization along with a detailed security report. ![GitHub Repo stars](https://img.shields.io/github/stars/splx-ai/agentic-radar?style=social)
 - [UQLM](https://github.com/cvs-health/uqlm): UQLM: Uncertainty Quantification for Language Models, is a Python library for LLM hallucination detection using state-of-the-art uncertainty quantification techniques ![GitHub Repo stars](https://img.shields.io/github/stars/cvs-health/uqlm?style=social)
+- [langchain-quantoracle](https://github.com/QuantOracledev/quantoracle) - LangChain toolkit for QuantOracle, a free quant finance API with 63 deterministic endpoints for options pricing, risk analysis, portfolio optimization, and technical indicators. ![GitHub Repo stars](https://img.shields.io/github/stars/QuantOracledev/quantoracle?style=social)
 
 ### Agents
 


### PR DESCRIPTION
langchain-quantoracle is a LangChain toolkit for QuantOracle, a free quant finance computation API. It auto-generates StructuredTools from the OpenAPI spec for 63 deterministic endpoints covering options pricing, risk metrics, portfolio optimization, Monte Carlo simulation, and more.

- PyPI: `pip install langchain-quantoracle`
- GitHub: https://github.com/QuantOracledev/quantoracle