### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ List of non-official ports of LangChain to other languages.
 - [LangWatch](https://github.com/langwatch/langwatch): An Open Source tool for observing, evaluating and optimising your llm apps and prompts, which supports LangChain out of the box! ![GitHub Repo stars](https://img.shields.io/github/stars/langwatch/langwatch?style=social)
 - [Agentic Radar](https://github.com/splx-ai/agentic-radar) - Open-source CLI security scanner for agentic workflows. Scans your workflow’s source code, detects vulnerabilities, and generates an interactive visualization along with a detailed security report. ![GitHub Repo stars](https://img.shields.io/github/stars/splx-ai/agentic-radar?style=social)
 - [UQLM](https://github.com/cvs-health/uqlm): UQLM: Uncertainty Quantification for Language Models, is a Python library for LLM hallucination detection using state-of-the-art uncertainty quantification techniques ![GitHub Repo stars](https://img.shields.io/github/stars/cvs-health/uqlm?style=social)
+- - [AgentOracle](https://github.com/TKCollective/langchain-agentoracle): Per-claim trust verification for LangChain agents. Confidence scoring (0.00–1.00) with ACT/VERIFY/REJECT recommendations before your agent acts.
 
 ### Agents
 


### PR DESCRIPTION
Add AgentOracle — per-claim trust verification for LangChain agents

Adds claim-level verification between data retrieval and agent action. Returns confidence scores (0.00–1.00) and ACT/VERIFY/REJECT recommendation per claim. 4-source verification including adversarial scanning. pip install langchain-agentoracle