### PR TITLE
feat: add AlgoVoi LangChain payment-gate adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ List of non-official ports of LangChain to other languages.
 
 - [GPTCache](https://github.com/zilliztech/GPTCache): A Library for Creating Semantic Cache for LLM Queries ![GitHub Repo stars](https://img.shields.io/github/stars/zilliztech/GPTCache?style=social)
 - [Gorilla](https://github.com/ShishirPatil/gorilla): An API store for LLMs ![GitHub Repo stars](https://img.shields.io/github/stars/ShishirPatil/gorilla?style=social)
+- [AlgoVoi LangChain Adapter](https://github.com/chopmob-cloud/AlgoVoi-Platform-Adapters/tree/master/ai-agent-frameworks/langchain): Payment-gate any LangChain chain or ReAct agent using x402, MPP, or AP2 — paid in USDC on Algorand, VOI, Hedera, or Stellar ![GitHub Repo stars](https://img.shields.io/github/stars/chopmob-cloud/AlgoVoi-Platform-Adapters?style=social)
 - [LlamaHub](https://github.com/emptycrown/llama-hub): a library of data loaders for LLMs made by the community ![GitHub Repo stars](https://img.shields.io/github/stars/emptycrown/llama-hub?style=social)
 - [Auto-evaluator](https://github.com/PineappleExpress808/auto-evaluator): a lightweight evaluation tool for question-answering using Langchain ![GitHub Repo stars](https://img.shields.io/github/stars/PineappleExpress808/auto-evaluator?style=social)
 - [Langchain visualizer](https://github.com/amosjyng/langchain-visualizer): visualization and debugging tool for LangChain workflows ![GitHub Repo stars](https://img.shields.io/github/stars/amosjyng/langchain-visualizer?style=social)


### PR DESCRIPTION
## Summary

Adds [AlgoVoi LangChain Adapter](https://github.com/chopmob-cloud/AlgoVoi-Platform-Adapters/tree/master/ai-agent-frameworks/langchain) to the **Services** section.

AlgoVoi is a multi-tenant payment infrastructure layer that payment-gates any LangChain chain or agent behind on-chain USDC verification. Supports `AlgoVoiLangChain` (Flask gate for any LCEL chain) and `AlgoVoiPaymentTool` (a `BaseTool` subclass for ReAct agents). Protocols: x402, MPP, AP2. Networks: Algorand, VOI, Hedera, Stellar.

- 76/77 unit tests, Phase 1 + Phase 2 PASS 5/5 chains
- Works with any `ChatModel` — OpenAI, Anthropic, Google, Groq, etc.
- Repo: https://github.com/chopmob-cloud/AlgoVoi-Platform-Adapters