### PR TITLE
Add PQS (Prompt Quality Score) — pre-inference prompt scoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ List of non-official ports of LangChain to other languages.
 - [LangWatch](https://github.com/langwatch/langwatch): An Open Source tool for observing, evaluating and optimising your llm apps and prompts, which supports LangChain out of the box! ![GitHub Repo stars](https://img.shields.io/github/stars/langwatch/langwatch?style=social)
 - [Agentic Radar](https://github.com/splx-ai/agentic-radar) - Open-source CLI security scanner for agentic workflows. Scans your workflow’s source code, detects vulnerabilities, and generates an interactive visualization along with a detailed security report. ![GitHub Repo stars](https://img.shields.io/github/stars/splx-ai/agentic-radar?style=social)
 - [UQLM](https://github.com/cvs-health/uqlm): UQLM: Uncertainty Quantification for Language Models, is a Python library for LLM hallucination detection using state-of-the-art uncertainty quantification techniques ![GitHub Repo stars](https://img.shields.io/github/stars/cvs-health/uqlm?style=social)
+- [PQS (Prompt Quality Score)](https://github.com/OnChainAIIntel/pqs-action) — Score any AI prompt on 8 dimensions before inference. GitHub Action gates prompts in CI. Python SDK, MCP server, REST API. MIT licensed.
 
 ### Agents
 


### PR DESCRIPTION
## What this adds

[**PQS (Prompt Quality Score)**](https://github.com/OnChainAIIntel/pqs-action) — a pre-inference prompt scoring system, added to the **Services** section.

## What PQS does

Scores any prompt on 8 dimensions (clarity, specificity, context, constraints, output format, role definition, examples, CoT structure) before inference runs. Built on PEEM, RAGAS, MT-Bench, G-Eval, and ROUGE frameworks.

## Why it fits here

PQS has a Python SDK with a LangChain integration. Developers can wrap LangChain chains with PQS scoring via `RunnableLambda` to validate prompts before they hit the chain. Makes pre-flight quality gating a one-liner for LangChain users.

## Ecosystem

- **GitHub Action**: [OnChainAIIntel/pqs-action](https://github.com/OnChainAIIntel/pqs-action) (GitHub Marketplace listed as "PQS Check")
- **Python SDK**: [prompt-quality-score](https://pypi.org/project/prompt-quality-score/) on PyPI
- **MCP server**: [pqs-mcp-server](https://www.npmjs.com/package/pqs-mcp-server) on npm (Smithery 88/100, Glama Official)
- **REST API**: [pqs.onchainintel.net](https://pqs.onchainintel.net) — free tier, no signup

MIT licensed. Happy to rework description or move to a different section if a better fit exists.
