### PR TITLE
Add VoiceTrace — voice pipeline observability tool built with LangGraph

### DIFF
--- a/README.md
+++ b/README.md
@@ -304,6 +304,7 @@ List of non-official ports of LangChain to other languages.
 - [TensorZero](https://github.com/tensorzero/tensorzero): An open-source framework for building production-grade LLM applications. It unifies an LLM gateway, observability, optimization, evaluations, and experimentation. ![GitHub Repo stars](https://img.shields.io/github/stars/tensorzero/tensorzero?style=social)
 - [Bifrost](https://github.com/maximhq/bifrost): Bifrost is the fastest LLM gateway, with just 11μs overhead at 5,000 RPS, making it 50x faster than LiteLLM. ![GitHub Repo stars](https://img.shields.io/github/stars/maximhq/bifrost?style=social)
 - [Mastra AI](https://github.com/mastra-ai/mastra): a framework for building AI-powered applications and agents with a modern TypeScript stack.
+- [VoiceTrace](https://github.com/weekendpm/voice-observation-v2): Voice pipeline observability — runs dual STT providers (Deepgram + Sarvam) side-by-side, attributes cross-modal failures to specific LangGraph nodes, and auto-generates prompt fixes via self-correction. ![GitHub Repo stars](https://img.shields.io/github/stars/weekendpm/voice-observation-v2?style=social)
 
 ## Complement to this list
 


### PR DESCRIPTION
## What is VoiceTrace?

[VoiceTrace](https://github.com/weekendpm/voice-observation-v2) is an observability dashboard for voice AI pipelines.

**The problem it solves:** Voice pipelines fail across 4 layers — STT, intent classification, LLM response, TTS — and failures are cross-modal (noisy audio → bad transcript → wrong intent → wrong response). Traditional logging tells you the output was bad, not which node broke first.

**How it uses LangGraph:** The entire pipeline is a LangGraph state machine. Each node (STT, intent, response, TTS) can fail independently and route to a root cause analysis node via conditional edges. This makes failure attribution precise and extensible.

**Features:**
- Dual STT provider comparison (Deepgram Nova-2 vs Sarvam Saarika) side-by-side on the same audio
- Prompt A/B testing for intent and response nodes
- AI-driven root cause analysis on failure
- Self-correction: auto-generates an improved prompt when a variant fails

**Stack:** LangGraph + FastAPI + Streamlit + GPT-4o-mini