### PR TITLE
Add langchain-haldir (governance for LangChain agents)

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ List of non-official ports of LangChain to other languages.
 - [LangWatch](https://github.com/langwatch/langwatch): An Open Source tool for observing, evaluating and optimising your llm apps and prompts, which supports LangChain out of the box! ![GitHub Repo stars](https://img.shields.io/github/stars/langwatch/langwatch?style=social)
 - [Agentic Radar](https://github.com/splx-ai/agentic-radar) - Open-source CLI security scanner for agentic workflows. Scans your workflow’s source code, detects vulnerabilities, and generates an interactive visualization along with a detailed security report. ![GitHub Repo stars](https://img.shields.io/github/stars/splx-ai/agentic-radar?style=social)
 - [UQLM](https://github.com/cvs-health/uqlm): UQLM: Uncertainty Quantification for Language Models, is a Python library for LLM hallucination detection using state-of-the-art uncertainty quantification techniques ![GitHub Repo stars](https://img.shields.io/github/stars/cvs-health/uqlm?style=social)
+- [langchain-haldir](https://github.com/ExposureGuard/haldir/tree/main/integrations/langchain-haldir): Governance layer for LangChain agents — per-agent permissions with spend caps, AES-encrypted secrets the model never sees, hash-chained tamper-evident audit trail, and instant session revocation. Drop-in `HaldirCallbackHandler` and `GovernedTool` wrapper. ![GitHub Repo stars](https://img.shields.io/github/stars/ExposureGuard/haldir?style=social)
 
 ### Agents
 


### PR DESCRIPTION
Adds [`langchain-haldir`](https://github.com/ExposureGuard/haldir/tree/main/integrations/langchain-haldir) to the Tools → Services section.

**What it is:** A governance layer for LangChain agents. Ships `HaldirCallbackHandler` (scope checks + audit logging on every tool call) and `GovernedTool.from_tool(...)` (wraps any LangChain tool with Haldir enforcement). Ten lines of code to add per-agent permissions, spend caps, encrypted secrets, and a tamper-evident audit trail to any LangChain app.

**Why it fits:** Direct LangChain integration (maintained as part of the Haldir project). Follows the existing Services list format. Placed at the end of the Services section.