### PR TITLE
Add noos-langchain to Services

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ List of non-official ports of LangChain to other languages.
 - [LangWatch](https://github.com/langwatch/langwatch): An Open Source tool for observing, evaluating and optimising your llm apps and prompts, which supports LangChain out of the box! ![GitHub Repo stars](https://img.shields.io/github/stars/langwatch/langwatch?style=social)
 - [Agentic Radar](https://github.com/splx-ai/agentic-radar) - Open-source CLI security scanner for agentic workflows. Scans your workflow’s source code, detects vulnerabilities, and generates an interactive visualization along with a detailed security report. ![GitHub Repo stars](https://img.shields.io/github/stars/splx-ai/agentic-radar?style=social)
 - [UQLM](https://github.com/cvs-health/uqlm): UQLM: Uncertainty Quantification for Language Models, is a Python library for LLM hallucination detection using state-of-the-art uncertainty quantification techniques ![GitHub Repo stars](https://img.shields.io/github/stars/cvs-health/uqlm?style=social)
+- [noos-langchain](https://github.com/Triangle-Technology/noos): Drop-in LangChain/LangGraph/CrewAI callback handler that halts tool-call retry loops, detects scope drift, and circuit-breaks on cost×quality decline. Backed by Rust core (44ns/event). ![GitHub Repo stars](https://img.shields.io/github/stars/Triangle-Technology/noos?style=social)
 
 ### Agents
 


### PR DESCRIPTION
Adds `noos-langchain` to the `### Services` section — alongside LangFair / LangWatch / Agentic Radar / UQLM as structural reliability/safety tooling for LangChain applications.

### What it is

`noos-langchain` is a drop-in `BaseCallbackHandler` that sits between your agent's retry loop and your LLM. It halts tool-call retry loops, detects scope drift, learns from user corrections across sessions, and circuit-breaks when cost compounds with quality decline — all as pre-delivery `Decision` values the app branches on.

Works with LangChain, LangGraph, and any agent library that accepts a `langchain-core` callback (CrewAI via `callbacks=[...]`, etc). Async variant `AsyncNoosCallbackHandler` for `ainvoke` / `astream`.

### Why it's not vaporware

I noticed the maintainer auto-closes brand-new repos with no history, so surfacing the traction signals upfront:

- Underlying Rust crate [`noos`](https://crates.io/crates/noos) on crates.io since 2026-04-16, currently at 0.4.0.
- Sibling bindings shipped to three registries: [`noos`](https://pypi.org/project/noos/) on PyPI, [`@triangle-technology/noos`](https://www.npmjs.com/package/@triangle-technology/noos) on npm, [`noos-langchain`](https://pypi.org/project/noos-langchain/) on PyPI.
- CI green across Rust × 3 platforms + Python binding + Node binding + LangChain adapter — see [.github/workflows/ci.yml](https://github.com/Triangle-Technology/noos/blob/main/.github/workflows/ci.yml).
- Criterion benchmarks on the hot path: 44 ns / event dispatch, ~2 µs per `decide()`, ~30 µs per realistic turn. Six orders of magnitude below an LLM call. Numbers in the [README Performance section](https://github.com/Triangle-Technology/noos#performance).
- Honest eval posture in the [README Eval Numbers section](https://github.com/Triangle-Technology/noos#eval-numbers) — real-LLM + real-judge results (Ollama N=29, Anthropic N=50) show quality parity (|Δ| ≤ 0.05) rather than inflated synthetic-oracle deltas. Infrastructure, not a quality booster.

### Why it belongs in `### Services`

The wedge is structural reliability at the callback layer, sibling to LangWatch (observability) + UQLM (uncertainty quantification) + LangFair (bias/fairness). Unlike `max_iterations` / `recursion_limit` which count total steps, `RepeatedToolCallLoop` fires on the signature of the pathology — 5+ consecutive invocations of the same tool without interleaving, the exact shape of the [November 2025 \$47k LangChain incident](https://github.com/langchain-ai/langchain/issues/13099).

### Entry

Placed at the bottom of `### Services` per contributing.md, following the existing `- [Name](url): description ![stars badge]` format.

MIT licensed.