### PR TITLE
Add EmblemAI agent wallet SDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ List of non-official ports of LangChain to other languages.
 - [BlockAGI](https://github.com/blockpipe/blockagi): BlockAGI conducts iterative, domain-specific research, and outputs detailed narrative reports to showcase its findings ![GitHub Repo stars](https://img.shields.io/github/stars/blockpipe/blockagi?style=social)
 - [waggledance.ai](https://github.com/agi-merge/waggle-dance): An opinionated, concurrent system of AI Agents. It implements Plan-Validate-Solve with data and tools for general goal-solving. ![GitHub Repo stars](https://img.shields.io/github/stars/agi-merge/waggle-dance?style=social)
 
+- [EmblemAI](https://github.com/EmblemCompany/EmblemAi-AgentWallet): Agent wallet SDK with 200+ crypto tools across 7 chains, usable via the MCP bridge in Claude Code / Cursor / Gemini CLI. Supports x402 micropayments and A2A. ![GitHub Repo stars](https://img.shields.io/github/stars/EmblemCompany/EmblemAi-AgentWallet?style=social)
 
 ### Templates
 


### PR DESCRIPTION
## Summary

Adding EmblemAI Agent Wallet to the Agents section — agent wallet SDK usable with LangChain via the MCP bridge.

## What it does

- **200+ crypto tools** across 7 blockchains (Solana, Ethereum, Base, BSC, Polygon, Hedera, Bitcoin) — swaps, DeFi, NFTs, cross-chain bridges, market intelligence
- **MCP bridge** — works in Claude Code, Cursor, Windsurf, Gemini CLI, any MCP-compliant LangChain tool wrapper
- **x402 micropayments** and A2A protocol support
- OAuth 2.0 + PKCE for standards-compliant install
- Open source, MIT licensed

## Install

```bash
claude mcp add --transport http emblem https://emblemvault.ai/api/mcp
```

Docs: https://emblemvault.ai/docs/mcp

## Checklist
- [x] Entry added at the end of the Agents section
- [x] Link works
- [x] Followed list format with GitHub stars badge