### PR TITLE
Add LangChain Hive (Hive Intelligence crypto-market integration)

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ List of non-official ports of LangChain to other languages.
 - [LangWatch](https://github.com/langwatch/langwatch): An Open Source tool for observing, evaluating and optimising your llm apps and prompts, which supports LangChain out of the box! ![GitHub Repo stars](https://img.shields.io/github/stars/langwatch/langwatch?style=social)
 - [Agentic Radar](https://github.com/splx-ai/agentic-radar) - Open-source CLI security scanner for agentic workflows. Scans your workflow’s source code, detects vulnerabilities, and generates an interactive visualization along with a detailed security report. ![GitHub Repo stars](https://img.shields.io/github/stars/splx-ai/agentic-radar?style=social)
 - [UQLM](https://github.com/cvs-health/uqlm): UQLM: Uncertainty Quantification for Language Models, is a Python library for LLM hallucination detection using state-of-the-art uncertainty quantification techniques ![GitHub Repo stars](https://img.shields.io/github/stars/cvs-health/uqlm?style=social)
+- [LangChain Hive](https://github.com/Sharpelabs/langchain-hive): LangChain integration for [Hive Intelligence](https://hiveintelligence.xyz/) — institutional-grade crypto market infrastructure for AI. Live prices, DeFi, wallets, and token risk via a managed MCP, REST API, or CLI. ![GitHub Repo stars](https://img.shields.io/github/stars/Sharpelabs/langchain-hive?style=social)
 
 ### Agents
 


### PR DESCRIPTION
Adds [LangChain Hive](https://github.com/Sharpelabs/langchain-hive) to the **Tools → Services** section.

LangChain Hive is the LangChain adapter for [Hive Intelligence](https://hiveintelligence.xyz/) — institutional-grade crypto market infrastructure for AI. It gives LangChain agents a managed MCP, REST API, or CLI surface covering live crypto prices, DeFi activity, wallet positions, and token risk across every major chain. Hundreds of normalized tools across 14 category-scoped endpoints; works with Claude, Cursor, ChatGPT, Gemini, Windsurf, and any MCP-compatible client.

Fits the Services section (external data layer for LangChain apps) alongside existing entries like LlamaHub, GPTCache, Jina, and Dify. Entry is in the standard `- [Name](github_url): description + star badge` format.