### PR TITLE
Add voidly-pay-langchain — autonomous agent-to-agent payments for LangChain agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ List of non-official ports of LangChain to other languages.
 - [Veritensor](https://github.com/arsbr/Veritensor) - Native security wrappers for LangChain DocumentLoaders to block prompt injections, stealth attacks, and PII leaks during RAG data ingestion. ![GitHub Repo stars](https://img.shields.io/github/stars/arsbr/Veritensor?style=social)
 - [Mengram](https://github.com/alibaizhanov/mengram): Long-term memory for LangChain agents — semantic, episodic & procedural memory with Graph RAG. Includes MengramRetriever for RAG pipelines. ![GitHub Repo stars](https://img.shields.io/github/stars/alibaizhanov/mengram?style=social)
 - [Ziran](https://github.com/taoq-ai/ziran): Open-source security testing framework for AI agents. Discovers dangerous tool chain compositions via graph analysis, detects execution-level side effects, and runs multi-phase trust exploitation campaigns. ![GitHub Repo stars](https://img.shields.io/github/stars/taoq-ai/ziran?style=social)
+- [Voidly Pay LangChain](https://github.com/voidly-ai/voidly-pay/tree/main/adapters/langchain): LangChain tools for autonomous agent-to-agent payments via the open Voidly Pay ledger (Ed25519-signed transfers, escrow, hire workflow, capability search). ![GitHub Repo stars](https://img.shields.io/github/stars/voidly-ai/voidly-pay?style=social)
 
 ### Agents
 


### PR DESCRIPTION
Adds **voidly-pay-langchain**, a LangChain adapter that exposes [Voidly Pay](https://github.com/voidly-ai/voidly-pay) primitives as LangChain tools so autonomous agents can pay each other.

**What Voidly Pay is:** an open off-chain credit ledger for agent-to-agent payments. Ed25519-signed envelopes, deterministic settlement, no blockchain required in Stage 1.

**Primitives exposed as LangChain tools:**
- `transfer` — signed credit transfer between agents
- `hire` — agent hire workflow with escrow
- `escrow` — hold + release funds on task completion
- `receipt` — fetch signed settlement receipt
- `capability_search` — find agents offering a capability + price

**Link:** https://github.com/voidly-ai/voidly-pay/tree/main/adapters/langchain

Added under the existing unsorted list block (same row as Mengram / Ziran / Veritensor), matching the list's current one-liner style with stars badge.

Maintainer: @EmperorMew