### PR TITLE
Add OpenRegistry — live MCP server for 27 national company registries

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ List of non-official ports of LangChain to other languages.
 - [LangWatch](https://github.com/langwatch/langwatch): An Open Source tool for observing, evaluating and optimising your llm apps and prompts, which supports LangChain out of the box! ![GitHub Repo stars](https://img.shields.io/github/stars/langwatch/langwatch?style=social)
 - [Agentic Radar](https://github.com/splx-ai/agentic-radar) - Open-source CLI security scanner for agentic workflows. Scans your workflow’s source code, detects vulnerabilities, and generates an interactive visualization along with a detailed security report. ![GitHub Repo stars](https://img.shields.io/github/stars/splx-ai/agentic-radar?style=social)
 - [UQLM](https://github.com/cvs-health/uqlm): UQLM: Uncertainty Quantification for Language Models, is a Python library for LLM hallucination detection using state-of-the-art uncertainty quantification techniques ![GitHub Repo stars](https://img.shields.io/github/stars/cvs-health/uqlm?style=social)
+- [OpenRegistry](https://github.com/sophymarine/openregistry): Live MCP server covering 27 national company registries — KYC / UBO / directors / filings / XBRL accounts across borders, no API key. ![GitHub Repo stars](https://img.shields.io/github/stars/sophymarine/openregistry?style=social)
 
 ### Agents
 


### PR DESCRIPTION
Adds [OpenRegistry](https://github.com/sophymarine/openregistry) to ### Services under ## Tools.

OpenRegistry is a live MCP server that connects LangChain agents (via [langchain-mcp-adapters](https://github.com/langchain-ai/langchain-mcp-adapters)) to 27 official government company registries — UK Companies House, Norway Brønnøysund, France INSEE, Germany Handelsregister, Spain BORME, Korea OpenDART, Canada CBCA, and more.

Use cases: KYC / KYB onboarding, cross-border UBO chain-walking, director/officer search, corporate filing monitors, XBRL accounts retrieval, shell-company detection.

Free anonymous tier (20 req/min, no API key), Streamable HTTP transport, released under CC-BY-4.0 docs license. Grade A on Glama's MCP Connector index (Tool-Definition-Quality 4.6/5 across 27 tools).

- Docs + LangChain quickstart: https://openregistry.sophymarine.com/docs/integrations/langchain
- Official MCP Registry: io.github.sophymarine/openregistry
