### PR TITLE
Add LangChain QuantOracle to Services

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ List of non-official ports of LangChain to other languages.
 - [LangWatch](https://github.com/langwatch/langwatch): An Open Source tool for observing, evaluating and optimising your llm apps and prompts, which supports LangChain out of the box! ![GitHub Repo stars](https://img.shields.io/github/stars/langwatch/langwatch?style=social)
 - [Agentic Radar](https://github.com/splx-ai/agentic-radar) - Open-source CLI security scanner for agentic workflows. Scans your workflow’s source code, detects vulnerabilities, and generates an interactive visualization along with a detailed security report. ![GitHub Repo stars](https://img.shields.io/github/stars/splx-ai/agentic-radar?style=social)
 - [UQLM](https://github.com/cvs-health/uqlm): UQLM: Uncertainty Quantification for Language Models, is a Python library for LLM hallucination detection using state-of-the-art uncertainty quantification techniques ![GitHub Repo stars](https://img.shields.io/github/stars/cvs-health/uqlm?style=social)
+- [LangChain QuantOracle](https://github.com/QuantOracledev/quantoracle): 73 deterministic quant finance calculators (options pricing + 10 Greeks, VaR, Sharpe, Kelly, Monte Carlo, GARCH, backtests) for LangChain agents. Free tier + x402 micropayments on Base or Solana. ![GitHub Repo stars](https://img.shields.io/github/stars/QuantOracledev/quantoracle?style=social)
 
 ### Agents
 


### PR DESCRIPTION
Adds [LangChain QuantOracle](https://github.com/QuantOracledev/quantoracle) to the Services section.

## What it is

- 63 deterministic quant calculators + 10 composite workflows + batch endpoint — total 73 endpoints
- Black-Scholes + 10 Greeks (incl. vanna, charm, speed), implied volatility, exotic derivatives (barrier, Asian, lookback)
- Risk metrics (Sharpe, Sortino, Calmar, VaR, CVaR, Kelly, drawdown), Monte Carlo, technical indicators, statistics (cointegration, Hurst, GARCH), portfolio optimization, FX/macro, TVM
- Composite workflows: backtest, rebalance-plan, options strategy optimizer, hedging recommender, full risk tearsheet
- Citation-verified against Hull / Wilmott / Bailey-Lopez-de-Prado

## Why a LangChain integration

LLMs are unreliable at *computing* finance math (Black-Scholes drifts run-to-run, higher-order Greeks frequently wrong). The pattern of "LLM for reasoning + deterministic API for compute" is what works for production agent systems doing finance. The PyPI package `langchain-quantoracle` exposes all 73 endpoints as `StructuredTool`s with categories filter.

## Free / paid

- 1,000 free calls per IP per day, no API key, no signup
- Paid composites via [x402](https://x402.org) USDC micropayments on Base or Solana ($0.002–$0.10 per call)
- Cataloged in CDP Bazaar (the Coinbase-run x402 discovery service) so any Coinbase AgentKit agent discovers it natively

## Cookbook

There's a one-page Jupyter notebook in the repo at `integrations/langchain/cookbook/quantoracle_risk_analyst.ipynb` showing a 25-line agent answering risk + Kelly questions with real reproducible outputs.