### PR TITLE
Add EnigmAgent — local secret vault with LangChain callbacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ List of non-official ports of LangChain to other languages.
 - [LangWatch](https://github.com/langwatch/langwatch): An Open Source tool for observing, evaluating and optimising your llm apps and prompts, which supports LangChain out of the box! ![GitHub Repo stars](https://img.shields.io/github/stars/langwatch/langwatch?style=social)
 - [Agentic Radar](https://github.com/splx-ai/agentic-radar) - Open-source CLI security scanner for agentic workflows. Scans your workflow’s source code, detects vulnerabilities, and generates an interactive visualization along with a detailed security report. ![GitHub Repo stars](https://img.shields.io/github/stars/splx-ai/agentic-radar?style=social)
 - [UQLM](https://github.com/cvs-health/uqlm): UQLM: Uncertainty Quantification for Language Models, is a Python library for LLM hallucination detection using state-of-the-art uncertainty quantification techniques ![GitHub Repo stars](https://img.shields.io/github/stars/cvs-health/uqlm?style=social)
+- [EnigmAgent](https://github.com/Agnuxo1/EnigmAgent): Local secret vault with LangChain callbacks. Resolve `{{PLACEHOLDER}}` tokens transparently in any chain or agent — API keys never enter the LLM context. AES-256-GCM + Argon2id. ![GitHub Repo stars](https://img.shields.io/github/stars/Agnuxo1/EnigmAgent?style=social)
 
 ### Agents
 


### PR DESCRIPTION
Adding [EnigmAgent](https://github.com/Agnuxo1/EnigmAgent) to the **Services** section.

**EnigmAgent** is a local AES-256-GCM + Argon2id encrypted vault with LangChain callbacks. Resolves `{{PLACEHOLDER}}` tokens transparently in any chain or agent — API keys never enter the LLM context. Zero cloud, MIT licensed.

- Native LangChain callback integration
- Vault unlocked locally with Argon2id  
- Works with any LLM provider (OpenAI, Anthropic, Groq, etc.)
- npm: `enigmagent-mcp` | GitHub: https://github.com/Agnuxo1/EnigmAgent