### PR TITLE
Add pdfmux to Knowledge Management

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ List of non-official ports of LangChain to other languages.
 - [Repochat](https://github.com/pnkvalavala/repochat): Chatbot assistant enabling GitHub repository interaction using LLMs with Retrieval Augmented Generation ![GitHub Repo stars](https://img.shields.io/github/stars/pnkvalavala/repochat?style=social)
 - [SolidGPT](https://github.com/AI-Citizen/SolidGPT): Chat everything with your code repository, ask repository level code questions, and discuss your requirements ![GitHub Repo stars](https://img.shields.io/github/stars/AI-Citizen/SolidGPT?style=social)
 - [Minima](https://github.com/dmayboroda/minima): Chat with local documents, connect local environment to ChatGPT or Claude ![GitHub Repo stars](https://img.shields.io/github/stars/dmayboroda/minima?style=social)
+- [pdfmux](https://github.com/NameetP/pdfmux): PDF-to-Markdown extraction with per-page confidence scoring and self-healing fallback. Native LangChain document loader (`PdfmuxLoader`); built for RAG pipelines that can't tolerate silent extraction failures. ![GitHub Repo stars](https://img.shields.io/github/stars/NameetP/pdfmux?style=social)
 
 ### Other / Chatbots
 


### PR DESCRIPTION
Adding **pdfmux**, a Python PDF-to-Markdown extractor with native LangChain integration. The unique angle: per-page confidence scoring with automatic re-extraction of low-confidence pages — solves the most common RAG failure mode where one bad page silently breaks retrieval.

```python
from langchain_pdfmux import PdfmuxLoader
docs = PdfmuxLoader("file.pdf").load()
```

Ranks #2 on the [opendataloader-bench](https://github.com/opendatalab/opendataloader-bench) reading-order benchmark. MIT licensed. PyPI: `pip install pdfmux langchain-pdfmux`.