### PR TITLE
Add Consensus Engine — query 11 frontier LLMs in parallel

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,8 @@ List of non-official ports of LangChain to other languages.
 
 ## Tools
 
+- [Consensus Engine](https://github.com/MICONNM/consensus-engine-py) - API client that queries 11 frontier LLMs in parallel and synthesizes consensus with confidence score. Useful for AI-assisted decision-making where ensemble disagreement is signal.
+
 ### Low-code
 
 - [Flowise](https://github.com/FlowiseAI/Flowise): Drag & drop UI to build your customized LLM flow using LangchainJS ![GitHub Repo stars](https://img.shields.io/github/stars/FlowiseAI/Flowise?style=social)


### PR DESCRIPTION
## What

Adding [Consensus Engine](https://github.com/MICONNM/consensus-engine-py) — a Python client for an API that polls 11 frontier LLMs in parallel (Llama 4 Maverick, Mistral Large 3 675B, Qwen 3.5 397B, Qwen3-Coder 480B, Llama 3.1 405B, Nemotron Ultra 253B, GLM-5.1, DeepSeek V4 Pro, Kimi K2.5, MiniMax M2.7) and returns one synthesized answer with confidence score.

## Why

Helps with AI-assisted decision-making where the **divergence** between models is the real signal — harder to fake with a single LLM.

## Try it

- Live demo (no signup, 10 questions/day per IP): https://api.yanmiayn.com/demo
- Python client: https://github.com/MICONNM/consensus-engine-py
- MIT License

## Honest disclosure

Solo dev project. Open beta. The free tier uses NVIDIA NIM open-source models so marginal cost is ~$0. I'd appreciate feedback if you find it useful (or not).
