### PR TITLE
Add distill-json to Tools/Services

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ List of non-official ports of LangChain to other languages.
 - [LangWatch](https://github.com/langwatch/langwatch): An Open Source tool for observing, evaluating and optimising your llm apps and prompts, which supports LangChain out of the box! ![GitHub Repo stars](https://img.shields.io/github/stars/langwatch/langwatch?style=social)
 - [Agentic Radar](https://github.com/splx-ai/agentic-radar) - Open-source CLI security scanner for agentic workflows. Scans your workflow’s source code, detects vulnerabilities, and generates an interactive visualization along with a detailed security report. ![GitHub Repo stars](https://img.shields.io/github/stars/splx-ai/agentic-radar?style=social)
 - [UQLM](https://github.com/cvs-health/uqlm): UQLM: Uncertainty Quantification for Language Models, is a Python library for LLM hallucination detection using state-of-the-art uncertainty quantification techniques ![GitHub Repo stars](https://img.shields.io/github/stars/cvs-health/uqlm?style=social)
+- [distill-json](https://github.com/karthyick/DISTILL): Lossless JSON compression for LLM payloads — reduces tokens 60-85% while staying LLM-readable, drop-in replacement for `json.dumps()` in RAG and agent tool outputs ![GitHub Repo stars](https://img.shields.io/github/stars/karthyick/DISTILL?style=social)
 
 ### Agents
 


### PR DESCRIPTION
Adding [**distill-json**](https://github.com/karthyick/DISTILL) under **Tools → Services**.

It's a Python library for **lossless JSON compression of LLM payloads** — reduces tokens 60-85% on repeated/structured data while keeping output human-and-LLM-readable. It's a drop-in replacement for `json.dumps()` in LangChain RAG context, agent tool outputs, and any structured data passed to prompts.

**Why it fits LangChain users:**
- LangChain prompts often include large JSON blobs from retrievers, tools, or APIs — this directly cuts that token cost
- 100% lossless roundtrip (exact type preservation)
- No binary blobs, no encoding tricks — output is plain JSON that LLMs read fine
- `pip install distill-json` (~5K downloads)
- MIT license

Thanks for maintaining this list!