### PR TITLE
Add Mengram — multilingual memory layer for AI agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -306,6 +306,7 @@ List of non-official ports of LangChain to other languages.
 - [Bifrost](https://github.com/maximhq/bifrost): Bifrost is the fastest LLM gateway, with just 11μs overhead at 5,000 RPS, making it 50x faster than LiteLLM. ![GitHub Repo stars](https://img.shields.io/github/stars/maximhq/bifrost?style=social)
 - [Mastra AI](https://github.com/mastra-ai/mastra): a framework for building AI-powered applications and agents with a modern TypeScript stack.
 - [Promptise Foundry](https://github.com/promptise-com/foundry): Production Python framework for agentic AI — controllable reasoning, a full MCP server SDK, autonomous runtime, memory, governance, security, and observability. Works with any LangChain `BaseChatModel`. ![GitHub Repo stars](https://img.shields.io/github/stars/promptise-com/foundry?style=social)
+- [Mengram](https://github.com/alibaizhanov/mengram): Multilingual long-term memory layer for AI agents — semantic, episodic, and procedural memory exposed via REST API and MCP server. Native support for 23 languages via Cohere multilingual embeddings; integrates with LangChain via [langchain-mengram](https://pypi.org/project/langchain-mengram/). Self-hostable. ![GitHub Repo stars](https://img.shields.io/github/stars/alibaizhanov/mengram?style=social)
 
 ## Complement to this list
 


### PR DESCRIPTION
Adding [Mengram](https://github.com/alibaizhanov/mengram) to the **Other LLM Frameworks** section.

Mengram is a long-term memory layer for AI agents (semantic, episodic, procedural memory) exposed via REST API and MCP server. It includes a LangChain integration ([`langchain-mengram`](https://pypi.org/project/langchain-mengram/)) implementing `BaseChatMessageHistory` so it works as a drop-in memory backend with `ConversationBufferMemory` and `RunnableWithMessageHistory`.

The differentiator vs other entries in this section: native multilingual retrieval in 23 languages (Cohere multilingual-v3 embeddings) — not English-only.

**Links:**
- Repo: https://github.com/alibaizhanov/mengram
- Docs: https://docs.mengram.io/
- LangChain integration on PyPI: https://pypi.org/project/langchain-mengram/
- License: MIT

Happy to adjust placement or wording if needed.