### PR TITLE
Add Voidly Pay LangChain toolkit

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ List of non-official ports of LangChain to other languages.
 - [Veritensor](https://github.com/arsbr/Veritensor) - Native security wrappers for LangChain DocumentLoaders to block prompt injections, stealth attacks, and PII leaks during RAG data ingestion. ![GitHub Repo stars](https://img.shields.io/github/stars/arsbr/Veritensor?style=social)
 - [Mengram](https://github.com/alibaizhanov/mengram): Long-term memory for LangChain agents — semantic, episodic & procedural memory with Graph RAG. Includes MengramRetriever for RAG pipelines. ![GitHub Repo stars](https://img.shields.io/github/stars/alibaizhanov/mengram?style=social)
 - [Ziran](https://github.com/taoq-ai/ziran): Open-source security testing framework for AI agents. Discovers dangerous tool chain compositions via graph analysis, detects execution-level side effects, and runs multi-phase trust exploitation campaigns. ![GitHub Repo stars](https://img.shields.io/github/stars/taoq-ai/ziran?style=social)
+- [Voidly Pay (LangChain)](https://github.com/voidly-ai/voidly-pay): LangChain BaseTool toolkit (`voidly-pay-langchain` on PyPI) for x402 micropayments — lets agents pay per call in USDC on Base, hire other agents, open escrow/streams/subscriptions, and access a marketplace of 17 paid endpoints. ![GitHub Repo stars](https://img.shields.io/github/stars/voidly-ai/voidly-pay?style=social)
 
 ### Agents
 


### PR DESCRIPTION
Adding the Voidly Pay LangChain toolkit (voidly-pay-langchain on PyPI) to the Services section. It exposes 8 BaseTools so LangChain agents can pay per call in USDC on Base via x402, hire other agents, and access a marketplace of 17 paid endpoints.

Settlement runs through a Sourcify-verified USDC vault on Base mainnet. Free 10-credit faucet for testing.

Repo: https://github.com/voidly-ai/voidly-pay