### PR TITLE
Add Agent Amplifier under Tools > Services

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,8 @@ List of non-official ports of LangChain to other languages.
   
 ### Services
 
+- [Agent Amplifier](https://github.com/qualixar/agent-amplifier): Runtime amplification layer for LangChain agents. Five deterministic hooks add effort routing, goal anchoring, convergence detection, persona escalation, and token budgeting — zero extra LLM calls. Also wraps Claude Code, Cursor, GitHub Copilot, LangGraph, CrewAI, AgentScope. AGPL-3.0. ![GitHub Repo stars](https://img.shields.io/github/stars/qualixar/agent-amplifier?style=social)
+
 - [GPTCache](https://github.com/zilliztech/GPTCache): A Library for Creating Semantic Cache for LLM Queries ![GitHub Repo stars](https://img.shields.io/github/stars/zilliztech/GPTCache?style=social)
 - [Gorilla](https://github.com/ShishirPatil/gorilla): An API store for LLMs ![GitHub Repo stars](https://img.shields.io/github/stars/ShishirPatil/gorilla?style=social)
 - [LlamaHub](https://github.com/emptycrown/llama-hub): a library of data loaders for LLMs made by the community ![GitHub Repo stars](https://img.shields.io/github/stars/emptycrown/llama-hub?style=social)


### PR DESCRIPTION
Adding **Agent Amplifier v1.0.0** to `## Tools > ### Services` — a runtime amplification layer for LangChain agents (and 6 other host frameworks).

## What it is

Drop-in `AgentAmplifier(adapter=LangChainAdapter())` wraps any LangChain agent or chain and adds:

- Dynamic effort routing (5-tier complexity classifier)
- Goal anchor re-injection (anti-drift)
- LTI-stability convergence detection
- Escalating persona audit per iteration
- Cost-bounded token budget controller
- MoE-inspired tool shortlisting

All in deterministic Python — zero extra LLM calls, zero network — installs in one line.

## Why "Tools > Services" fits

The category currently holds runtime / orchestration services. Agent Amplifier sits one level below LangChain (at the hook layer) and one level above the model — it's a runtime amplification service that LangChain agents can opt into without changing their existing code.

If you'd prefer it under `## Complement to this list`, happy to move it — the framing works either way.

## Other supported hosts

LangChain is one of seven launch adapters: Claude Code, Cursor, GitHub Copilot, LangGraph, CrewAI, AgentScope, LangChain.

## Quality

- 1,741 tests
- 100% branch coverage
- mypy --strict
- ruff
- AGPL-3.0-or-later (commercial dual-license available)
- Dogfooded across 1.71B tokens / 22 sessions before shipping

## Links

- Repo: https://github.com/qualixar/agent-amplifier
- PyPI: https://pypi.org/project/agent-amplifier/
- Demo (78s): https://youtube.com/watch?v=arfkIS00eKg

## Format compliance

- [x] Standard `- [Name](url): description ![stars]` bullet
- [x] GitHub stars shields.io badge included
- [x] Concise factual description (no promotional language)
- [x] Placed in section that best matches function