### PR TITLE
Add langchain-dakera: persistent memory layer for LangChain agents via MCP

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ List of non-official ports of LangChain to other languages.
   
 ### Services
 
+- [Dakera](https://github.com/Dakera-AI/dakera): Self-hosted persistent memory server for LangChain agents — hybrid BM25 + vector recall, decay-weighted retrieval, and multi-agent namespacing. Native `langchain-dakera` integration package. ![GitHub Repo stars](https://img.shields.io/github/stars/Dakera-AI/dakera?style=social)
 - [GPTCache](https://github.com/zilliztech/GPTCache): A Library for Creating Semantic Cache for LLM Queries ![GitHub Repo stars](https://img.shields.io/github/stars/zilliztech/GPTCache?style=social)
 - [Gorilla](https://github.com/ShishirPatil/gorilla): An API store for LLMs ![GitHub Repo stars](https://img.shields.io/github/stars/ShishirPatil/gorilla?style=social)
 - [LlamaHub](https://github.com/emptycrown/llama-hub): a library of data loaders for LLMs made by the community ![GitHub Repo stars](https://img.shields.io/github/stars/emptycrown/llama-hub?style=social)

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ List of non-official ports of LangChain to other languages.
   
 ### Services
 
-- [Dakera](https://github.com/Dakera-AI/dakera): Self-hosted persistent memory server for LangChain agents — hybrid BM25 + vector recall, decay-weighted retrieval, and multi-agent namespacing. Native `langchain-dakera` integration package. ![GitHub Repo stars](https://img.shields.io/github/stars/Dakera-AI/dakera?style=social)
+- [Dakera](https://github.com/dakera-ai/dakera-deploy): Self-hosted persistent memory server for LangChain agents — hybrid BM25 + vector recall, decay-weighted retrieval, and multi-agent namespacing. Native `langchain-dakera` integration package. ![GitHub Repo stars](https://img.shields.io/github/stars/dakera-ai/dakera-deploy?style=social)
 - [GPTCache](https://github.com/zilliztech/GPTCache): A Library for Creating Semantic Cache for LLM Queries ![GitHub Repo stars](https://img.shields.io/github/stars/zilliztech/GPTCache?style=social)
 - [Gorilla](https://github.com/ShishirPatil/gorilla): An API store for LLMs ![GitHub Repo stars](https://img.shields.io/github/stars/ShishirPatil/gorilla?style=social)
 - [LlamaHub](https://github.com/emptycrown/llama-hub): a library of data loaders for LLMs made by the community ![GitHub Repo stars](https://img.shields.io/github/stars/emptycrown/llama-hub?style=social)

--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ List of non-official ports of LangChain to other languages.
 - [LangWatch](https://github.com/langwatch/langwatch): An Open Source tool for observing, evaluating and optimising your llm apps and prompts, which supports LangChain out of the box! ![GitHub Repo stars](https://img.shields.io/github/stars/langwatch/langwatch?style=social)
 - [Agentic Radar](https://github.com/splx-ai/agentic-radar) - Open-source CLI security scanner for agentic workflows. Scans your workflow’s source code, detects vulnerabilities, and generates an interactive visualization along with a detailed security report. ![GitHub Repo stars](https://img.shields.io/github/stars/splx-ai/agentic-radar?style=social)
 - [UQLM](https://github.com/cvs-health/uqlm): UQLM: Uncertainty Quantification for Language Models, is a Python library for LLM hallucination detection using state-of-the-art uncertainty quantification techniques ![GitHub Repo stars](https://img.shields.io/github/stars/cvs-health/uqlm?style=social)
+- [langchain-dakera](https://github.com/Dakera-AI/dakera-mcp): Persistent decay-weighted memory layer for LangChain agents — connect to a self-hosted Rust memory server with knowledge graph and temporal recall via MCP. ![GitHub Repo stars](https://img.shields.io/github/stars/Dakera-AI/dakera-mcp?style=social)
 
 ### Agents
 


### PR DESCRIPTION
## Description

Adds **langchain-dakera** to the Services section under Tools.

**langchain-dakera** is a persistent, decay-weighted memory layer for LangChain agents that connects to a self-hosted Rust memory server. It provides:

- **Knowledge graph memory** — entities and relationships stored and traversed across sessions
- **Temporal recall** — time-aware memory retrieval so agents know not just what happened but when
- **Decay weighting** — recent and high-importance memories surface first, mimicking human memory prioritization
- **MCP interface** — standard Model Context Protocol integration, self-hosted with no data leaving your infrastructure

Fits naturally in the Services section alongside other infrastructure-layer tools.

**GitHub:** https://github.com/Dakera-AI/dakera-mcp