### PR TITLE
Add TheCrawler to Tools > Services

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ List of non-official ports of LangChain to other languages.
 - [LangWatch](https://github.com/langwatch/langwatch): An Open Source tool for observing, evaluating and optimising your llm apps and prompts, which supports LangChain out of the box! ![GitHub Repo stars](https://img.shields.io/github/stars/langwatch/langwatch?style=social)
 - [Agentic Radar](https://github.com/splx-ai/agentic-radar) - Open-source CLI security scanner for agentic workflows. Scans your workflow’s source code, detects vulnerabilities, and generates an interactive visualization along with a detailed security report. ![GitHub Repo stars](https://img.shields.io/github/stars/splx-ai/agentic-radar?style=social)
 - [UQLM](https://github.com/cvs-health/uqlm): UQLM: Uncertainty Quantification for Language Models, is a Python library for LLM hallucination detection using state-of-the-art uncertainty quantification techniques ![GitHub Repo stars](https://img.shields.io/github/stars/cvs-health/uqlm?style=social)
+- [TheCrawler](https://github.com/manchittlab/TheCrawler): Open-source web scraper with LLM-powered structured extraction. Pass a JSON Schema, get parsed typed data via any OpenAI-compatible endpoint (OpenAI, llama.cpp, vLLM, LM Studio, Ollama). CLI, npm, REST API, and MCP server with 5 tools. ![GitHub Repo stars](https://img.shields.io/github/stars/manchittlab/TheCrawler?style=social)
 
 ### Agents
 


### PR DESCRIPTION
TheCrawler is an open-source (AGPL-3.0) scraper with LLM-powered structured extraction designed to feed LangChain pipelines directly.

- Repo: https://github.com/manchittlab/TheCrawler
- npm: `thecrawler@0.1.1`
- MCP Registry: `io.github.manchittlab/thecrawler@0.1.1`

Why it fits Services:
- Returns clean, boilerplate-stripped markdown ready for embeddings (heading-aware RAG chunks with overlap)
- Endpoint-agnostic extract: pass a JSON Schema, get parsed typed data back via any OpenAI-compatible LLM (OpenAI / llama.cpp / vLLM / LM Studio / Ollama)
- Structured `errorType` enum + `retryable` flag — agents branch programmatically rather than regex-matching error strings
- Adaptive Cheerio → Playwright fallback when an SPA shell is detected
- 16 analytics-tracker detection, JSON-LD parsing, commerce data, forms, microdata out of the box

Placed alphabetically in the Services section (T-) immediately after `UQLM`. Happy to relocate if you'd prefer a different section.