### PR TITLE
Add invisible-playwright to Tools/Services

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ List of non-official ports of LangChain to other languages.
 - [LangWatch](https://github.com/langwatch/langwatch): An Open Source tool for observing, evaluating and optimising your llm apps and prompts, which supports LangChain out of the box! ![GitHub Repo stars](https://img.shields.io/github/stars/langwatch/langwatch?style=social)
 - [Agentic Radar](https://github.com/splx-ai/agentic-radar) - Open-source CLI security scanner for agentic workflows. Scans your workflow’s source code, detects vulnerabilities, and generates an interactive visualization along with a detailed security report. ![GitHub Repo stars](https://img.shields.io/github/stars/splx-ai/agentic-radar?style=social)
 - [UQLM](https://github.com/cvs-health/uqlm): UQLM: Uncertainty Quantification for Language Models, is a Python library for LLM hallucination detection using state-of-the-art uncertainty quantification techniques ![GitHub Repo stars](https://img.shields.io/github/stars/cvs-health/uqlm?style=social)
+- [invisible-playwright](https://github.com/feder-cr/invisible_playwright): Playwright wrapper for a stealth-patched Firefox 150 binary. Drop-in `Browser` for LangChain Playwright Toolkit when targets have anti-bot guardrails (reCAPTCHA, FingerprintPro, Cloudflare). ![GitHub Repo stars](https://img.shields.io/github/stars/feder-cr/invisible_playwright?style=social)
 
 ### Agents
 


### PR DESCRIPTION
Playwright wrapper for a stealth-patched Firefox 150 binary. Drop-in `Browser` object for LangChain agents that use the Playwright toolkit and run into anti-bot guardrails (reCAPTCHA v3, FingerprintPro, Cloudflare) on real-world targets.

Unblocks agents like GPT Researcher and similar autonomous web researchers when they hit sites that block headless / vanilla Playwright. Anti-fingerprinting happens in the C++ source (15 patches against mozilla-central) instead of as JS overrides, so the patches don't leave detectable shims.

(Same author as the invisible-playwright entry in awesome-agents #476.)

Self-disclosure: I am the author. Repo: https://github.com/feder-cr/invisible_playwright