### PR TITLE
Add Black_Wall to Tools/Services (pre-action risk gate for LangChain agents)

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ List of non-official ports of LangChain to other languages.
 - [LangWatch](https://github.com/langwatch/langwatch): An Open Source tool for observing, evaluating and optimising your llm apps and prompts, which supports LangChain out of the box! ![GitHub Repo stars](https://img.shields.io/github/stars/langwatch/langwatch?style=social)
 - [Agentic Radar](https://github.com/splx-ai/agentic-radar) - Open-source CLI security scanner for agentic workflows. Scans your workflow’s source code, detects vulnerabilities, and generates an interactive visualization along with a detailed security report. ![GitHub Repo stars](https://img.shields.io/github/stars/splx-ai/agentic-radar?style=social)
 - [UQLM](https://github.com/cvs-health/uqlm): UQLM: Uncertainty Quantification for Language Models, is a Python library for LLM hallucination detection using state-of-the-art uncertainty quantification techniques ![GitHub Repo stars](https://img.shields.io/github/stars/cvs-health/uqlm?style=social)
+- [Black_Wall](https://github.com/bluetieroperations-create/blackwall-integrations): Drop-in pre-action risk gate for LangChain tools — vets an agent’s action (send email, run SQL, make a payment) before it runs and returns GO/CONFIRM/STOP with red-flag codes. ![GitHub Repo stars](https://img.shields.io/github/stars/bluetieroperations-create/blackwall-integrations?style=social)
 
 ### Agents
 


### PR DESCRIPTION
Adds **Black_Wall** to the Tools → Services list, alongside the existing safety/eval tools (Agentic Radar, LangFair, UQLM).

**What it is:** a pre-action risk gate for AI agents. Before a LangChain tool runs a consequential action (send an email, run SQL, make a payment, delete a file), the agent calls Black_Wall and gets back a risk score (0–100), red-flag codes, and a GO / CONFIRM / STOP gate — in time to stop a mistake.

**Why it fits:** it's a drop-in LangChain integration (a tool wrapper / `guard_tool`), open-source (MIT), and complements the observability/eval tools already listed — this is the prevention layer that runs *before* the action.

Link points to the open-source integration guards (LangChain, plus CrewAI / Vercel AI SDK / OpenAI). Free tier, no card.

Thanks for maintaining this list!