### PR TITLE
Add TWZRD Agent Intel — Solana x402 trust MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ List of non-official ports of LangChain to other languages.
 - [LangWatch](https://github.com/langwatch/langwatch): An Open Source tool for observing, evaluating and optimising your llm apps and prompts, which supports LangChain out of the box! ![GitHub Repo stars](https://img.shields.io/github/stars/langwatch/langwatch?style=social)
 - [Agentic Radar](https://github.com/splx-ai/agentic-radar) - Open-source CLI security scanner for agentic workflows. Scans your workflow’s source code, detects vulnerabilities, and generates an interactive visualization along with a detailed security report. ![GitHub Repo stars](https://img.shields.io/github/stars/splx-ai/agentic-radar?style=social)
 - [UQLM](https://github.com/cvs-health/uqlm): UQLM: Uncertainty Quantification for Language Models, is a Python library for LLM hallucination detection using state-of-the-art uncertainty quantification techniques ![GitHub Repo stars](https://img.shields.io/github/stars/cvs-health/uqlm?style=social)
+- [TWZRD Agent Intel](https://intel.twzrd.xyz): Trust-scoring MCP server for x402 agents on Solana. Free preflight + paid signed trust receipt via <1s USDC settlement. [Website](https://intel.twzrd.xyz) | [MCP](https://intel.twzrd.xyz/mcp)
 
 ### Agents
 


### PR DESCRIPTION
## Summary

Adds [TWZRD Agent Intel](https://intel.twzrd.xyz) to the Services section.

**TWZRD Agent Intel** is a trust-scoring MCP server for x402 agents on Solana. It provides:
- Free preflight trust check for any Solana wallet (on-chain activity, transaction patterns, network age)
- Paid signed `twzrd.receipt.v5` trust receipts via USDC micropayment (<1s settlement)
- Streamable-HTTP MCP endpoint at `https://intel.twzrd.xyz/mcp`
- First Solana-native x402 MCP for agent identity verification

Fits naturally in the **Services** section as it's a production LangChain-compatible service for agent trust verification.

**Links:** [Website](https://intel.twzrd.xyz) | [MCP](https://intel.twzrd.xyz/mcp) | [OpenAPI](https://intel.twzrd.xyz/openapi.json) | [GitHub](https://github.com/twzrd-sol/wzrd-final)