### PR TITLE
Add langchain-api-guard to Services

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ List of non-official ports of LangChain to other languages.
 - [LangWatch](https://github.com/langwatch/langwatch): An Open Source tool for observing, evaluating and optimising your llm apps and prompts, which supports LangChain out of the box! ![GitHub Repo stars](https://img.shields.io/github/stars/langwatch/langwatch?style=social)
 - [Agentic Radar](https://github.com/splx-ai/agentic-radar) - Open-source CLI security scanner for agentic workflows. Scans your workflow’s source code, detects vulnerabilities, and generates an interactive visualization along with a detailed security report. ![GitHub Repo stars](https://img.shields.io/github/stars/splx-ai/agentic-radar?style=social)
 - [UQLM](https://github.com/cvs-health/uqlm): UQLM: Uncertainty Quantification for Language Models, is a Python library for LLM hallucination detection using state-of-the-art uncertainty quantification techniques ![GitHub Repo stars](https://img.shields.io/github/stars/cvs-health/uqlm?style=social)
+- [langchain-api-guard](https://github.com/ShipProtocol/langchain-api-guard): A local SQLite ledger and Python wrapper to track OpenAI API costs and prevent runaway billing without cloud lag. ![GitHub Repo stars](https://img.shields.io/github/stars/ShipProtocol/langchain-api-guard?style=social)
 
 ### Agents
 


### PR DESCRIPTION
Hi maintainers,
I built a local SQLite ledger and Python wrapper to track OpenAI API costs and prevent runaway LangChain billing without relying on laggy cloud dashboards. Thought it might be a highly useful, zero-dependency utility for the community under the Services category.
(P.S. I also run a private 50% rev-share syndicate for technical writers/devs who want to review the OS-level production version of this tool. If you or your contributors write about AI dev tools, I’d love to send you a free copy and a custom tracking link. Let me know!)
Thanks for maintaining this incredible list.