### PR TITLE
Add langchain-skim (x402 web reader document loader)

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,7 @@ List of non-official ports of LangChain to other languages.
 - [SolidGPT](https://github.com/AI-Citizen/SolidGPT): Chat everything with your code repository, ask repository level code questions, and discuss your requirements ![GitHub Repo stars](https://img.shields.io/github/stars/AI-Citizen/SolidGPT?style=social)
 - [Minima](https://github.com/dmayboroda/minima): Chat with local documents, connect local environment to ChatGPT or Claude ![GitHub Repo stars](https://img.shields.io/github/stars/dmayboroda/minima?style=social)
 - [pdfmux](https://github.com/NameetP/pdfmux): PDF-to-Markdown extraction with per-page confidence scoring and self-healing fallback. Native LangChain document loader (`PdfmuxLoader`); built for RAG pipelines that can't tolerate silent extraction failures. ![GitHub Repo stars](https://img.shields.io/github/stars/NameetP/pdfmux?style=social)
+- [langchain-skim](https://pypi.org/project/langchain-skim/): A native LangChain document loader that turns any URL into clean, agent-ready Markdown via the [Skim](https://skim402.com) x402 reader API - paid per call in USDC on Base, no API keys, built for RAG pipelines.
 
 ### Other / Chatbots
 


### PR DESCRIPTION
Adds `langchain-skim` under Open Source Projects -> Knowledge Management, next to the other document-loader entry (pdfmux).

`langchain-skim` is an open-source (MIT, on PyPI) native LangChain document loader that turns any URL into clean, agent-ready Markdown for RAG pipelines. It's powered by the [Skim](https://skim402.com) x402 reader API - reads are paid per call in USDC on Base over the [x402 protocol](https://x402.org), so there are no API keys. Happy to tweak wording/placement.