### PR TITLE
Add langchain-tool-gate to Tools list

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ List of non-official ports of LangChain to other languages.
 - [Langchain-rust](https://github.com/Abraxas-365/langchain-rust): LangChain for Rust ![GitHub Repo stars](https://img.shields.io/github/stars/Abraxas-365/langchain-rust?style=social)
 
 ## Tools
-
+- [langchain-tool-gate](https://github.com/yusishuma/langchain-tool-gate) — A lightweight tool management plugin for LangChain that adds approval workflows and dynamic activation for tools.
 ### Low-code
 
 - [Flowise](https://github.com/FlowiseAI/Flowise): Drag & drop UI to build your customized LLM flow using LangchainJS ![GitHub Repo stars](https://img.shields.io/github/stars/FlowiseAI/Flowise?style=social)


### PR DESCRIPTION
Add langchain-tool-gate to the Tools category. It's a lightweight plugin for LangChain that adds approval workflows and dynamic activation for tools.

Key features:
- Developers mark tools with `@governed_tool`
- New tools are registered as `pending` by default
- Operators activate them via CLI (`tool-gate approve`)
- Runtime only loads `active` tools, no restart required

Repo: https://github.com/yusishuma/langchain-tool-gate
PyPI: https://pypi.org/project/langchain-tool-gate/