### PR TITLE
Add Agents Launchpad to Complement section

### DIFF
--- a/README.md
+++ b/README.md
@@ -313,3 +313,4 @@ List of non-official ports of LangChain to other languages.
 - [Awesome LLM](https://github.com/Hannibal046/Awesome-LLM): Awesome-LLM: a curated list of Large Language Model resources. ![GitHub Repo stars](https://img.shields.io/github/stars/Hannibal046/Awesome-LLM?style=social)
 - [LLaMA Cult and More](https://github.com/shm007g/LLaMA-Cult-and-More): Keeping Track of Affordable LLMs, 🦙 Cult and More ![GitHub Repo stars](https://img.shields.io/github/stars/shm007g/LLaMA-Cult-and-More?style=social)
 - [Awesome Language Agents](https://github.com/ysymyth/awesome-language-agents): List of language agents based on paper "Cognitive Architectures for Language Agents" ![GitHub Repo stars](https://img.shields.io/github/stars/ysymyth/awesome-language-agents?style=social)
+- [Agents Launchpad](https://launchpad.smartbizcalc.com): A curated, community-ranked directory of the best indie AI agents — browse by category, upvote your favorites, and submit your own agent for free.


### PR DESCRIPTION
Adding [Agents Launchpad](https://launchpad.smartbizcalc.com) — a curated, community-ranked directory of indie AI agents — to the *Complement to this list* section.

It's a discovery resource for finding LangChain-compatible agents and AI tools, ranked by community upvotes. Fits naturally alongside existing resources in this section.